### PR TITLE
Dev

### DIFF
--- a/src/komodo_interest.h
+++ b/src/komodo_interest.h
@@ -104,13 +104,9 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
                 if ( exception == 0 )
                 {
                     numerator = (nValue / 20); // assumes 5%!
-                    if ( txheight < 30000 )
+                    if ( txheight < 300000 )
                         interest = (numerator / denominator);
-                    else
-                    {
-                        interest = (numerator * minutes) / ((uint64_t)365 * 24 * 60);
-                        printf("(%llu * %llu) = %llu; ",(long long)numerator,(long long)minutes,(long long)(numerator * minutes));
-                    }
+                    else interest = (numerator * minutes) / ((uint64_t)365 * 24 * 60);
                 }
                 else
                 {
@@ -125,7 +121,7 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
                     interest = (numerator / denominator) / COIN;
                 else interest = ((numerator * minutes) / ((uint64_t)365 * 24 * 60)) / COIN;
             }
-            fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
+            //fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
         }
     }
     return(interest);

--- a/src/komodo_interest.h
+++ b/src/komodo_interest.h
@@ -115,7 +115,7 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
                 numerator = (nValue * KOMODO_INTEREST);
                 interest = (numerator / denominator) / COIN;
             }
-            //fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
+            fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
         }
     }
     return(interest);

--- a/src/komodo_interest.h
+++ b/src/komodo_interest.h
@@ -102,7 +102,10 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
                 if ( exception == 0 )
                 {
                     numerator = (nValue / 20); // assumes 5%!
-                    interest = (numerator / denominator);
+                    if ( txheight < 236000 )
+                        interest = (numerator / denominator);
+                    else interest = (numerator * minutes) / ((uint64_t)365 * 24 * 60);
+
                 }
                 else
                 {
@@ -113,9 +116,11 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
             else
             {
                 numerator = (nValue * KOMODO_INTEREST);
-                interest = (numerator / denominator) / COIN;
+                if ( txheight < 300000 || numerator * minutes < 365 * 24 * 60 )
+                    interest = (numerator / denominator) / COIN;
+                else interest = ((numerator * minutes) / ((uint64_t)365 * 24 * 60)) / COIN;
             }
-            fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
+            //fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
         }
     }
     return(interest);

--- a/src/komodo_interest.h
+++ b/src/komodo_interest.h
@@ -73,6 +73,8 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
     {
         if ( (minutes= (tiptime - nLockTime) / 60) >= 60 )
         {
+            if ( minutes > 365 * 24 * 60 )
+                minutes = 365 * 24 * 60;
             denominator = (((uint64_t)365 * 24 * 60) / minutes);
             if ( denominator == 0 )
                 denominator = 1; // max KOMODO_INTEREST per transfer, do it at least annually!
@@ -102,10 +104,13 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
                 if ( exception == 0 )
                 {
                     numerator = (nValue / 20); // assumes 5%!
-                    if ( txheight < 236000 )
+                    if ( txheight < 30000 )
                         interest = (numerator / denominator);
-                    else interest = (numerator * minutes) / ((uint64_t)365 * 24 * 60);
-
+                    else
+                    {
+                        interest = (numerator * minutes) / ((uint64_t)365 * 24 * 60);
+                        printf("(%llu * %llu) = %llu; ",(long long)numerator,(long long)minutes,(long long)(numerator * minutes));
+                    }
                 }
                 else
                 {
@@ -120,7 +125,7 @@ uint64_t komodo_interest(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uin
                     interest = (numerator / denominator) / COIN;
                 else interest = ((numerator * minutes) / ((uint64_t)365 * 24 * 60)) / COIN;
             }
-            //fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
+            fprintf(stderr,"komodo_interest %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",(long long)nValue,(double)nValue/COIN,nLockTime,tiptime,minutes,(long long)interest,(double)interest/COIN,(long long)numerator,(long long)denominator);
         }
     }
     return(interest);


### PR DESCRIPTION
Fix interest granularity for long term utxo. 1/10 of a year to 1/9 has same interest result.

Change to new calculation of minutes / 365*24*60 directly instead of via intermediate denominator to eliminate integer clipping

Will activate at 300000 planned upgrade, so not urgent to update