### PR TITLE
Dev

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4964,9 +4964,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vector<CBlock> vHeaders;
         int nLimit = MAX_HEADERS_RESULTS;
         LogPrint("net", "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
-        fprintf(stderr,"getheaders from %d prev.%d\n",(int32_t)(pindex ? pindex->nHeight : -1),pfrom->lasthdrsreq);
         if ( pfrom->lasthdrsreq >= chainActive.Height()-MAX_HEADERS_RESULTS || pfrom->lasthdrsreq != (int32_t)(pindex ? pindex->nHeight : -1) )
         {
+            pfrom->lasthdrsreq = (int32_t)(pindex ? pindex->nHeight : -1);
             for (; pindex; pindex = chainActive.Next(pindex))
             {
                 vHeaders.push_back(pindex->GetBlockHeader());
@@ -4974,8 +4974,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     break;
             }
             pfrom->PushMessage("headers", vHeaders);
-            pfrom->lasthdrsreq = (int32_t)(pindex ? pindex->nHeight : -1);
-        }
+        } else fprintf(stderr,"ignore getheaders from peer.%d %d prev.%d\n",(int32_t)pfrom->id,(int32_t)(pindex ? pindex->nHeight : -1),pfrom->lasthdrsreq);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4583,7 +4583,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
-    fprintf(stderr, "recv: %s peer=%s\n", SanitizeString(strCommand), pfrom->addr.ToString().c_str());
+    fprintf(stderr, "recv: %s peer=%d\n", SanitizeString(strCommand), pfrom->id);
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4583,7 +4583,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
-    fprintf(stderr, "recv: %s peer=%d\n", SanitizeString(strCommand), pfrom->id);
+    fprintf(stderr, "recv: %s peer=%d\n", SanitizeString(strCommand).c_str(), (itn32_t)pfrom->GetId());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4495,7 +4495,11 @@ void static ProcessGetData(CNode* pfrom)
                     {
                         if (inv.type == MSG_BLOCK)
                         {
-                            fprintf(stderr,"send block %d\n",komodo_block2height(&block));
+                            uint256 hash; int32_t z;
+                            hash = block.GetHash();
+                            for (z=0; z<32; z++)
+                                printf("%02x",((uint8_t *)&hash)[z]);
+                            fprintf(stderr," send block %d\n",komodo_block2height(&block));
                             pfrom->PushMessage("block", block);
                         }
                         else // MSG_FILTERED_BLOCK)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4583,7 +4583,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
-    fprintf(stderr, "recv: %s (%u bytes) peer=%s\n", SanitizeString(strCommand), vRecv.size(), pfrom->addr.ToString());
+    fprintf(stderr, "recv: %s (%u bytes) peer=%s\n", SanitizeString(strCommand), vRecv.size(), pfrom->addr.ToString().c_str());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4583,7 +4583,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
-    fprintf(stderr, "recv: %s (%u bytes) peer=%s\n", SanitizeString(strCommand), vRecv.size(), pfrom->addr.ToString().c_str());
+    fprintf(stderr, "recv: %s peer=%s\n", SanitizeString(strCommand), pfrom->addr.ToString().c_str());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4964,14 +4964,18 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vector<CBlock> vHeaders;
         int nLimit = MAX_HEADERS_RESULTS;
         LogPrint("net", "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
-        //fprintf(stderr,"getheaders from %d\n",(int32_t)(pindex ? pindex->nHeight : -1));
-        for (; pindex; pindex = chainActive.Next(pindex))
+        fprintf(stderr,"getheaders from %d prev.%d\n",(int32_t)(pindex ? pindex->nHeight : -1),pfrom->lasthdrsreq);
+        if ( pfrom->lasthdrsreq != (int32_t)(pindex ? pindex->nHeight : -1) )
         {
-            vHeaders.push_back(pindex->GetBlockHeader());
-            if (--nLimit <= 0 || pindex->GetBlockHash() == hashStop)
-                break;
+            for (; pindex; pindex = chainActive.Next(pindex))
+            {
+                vHeaders.push_back(pindex->GetBlockHeader());
+                if (--nLimit <= 0 || pindex->GetBlockHash() == hashStop)
+                    break;
+            }
+            pfrom->PushMessage("headers", vHeaders);
+            pfrom->lasthdrsreq = (int32_t)(pindex ? pindex->nHeight : -1);
         }
-        pfrom->PushMessage("headers", vHeaders);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@ using namespace std;
  */
 
 CCriticalSection cs_main;
+extern uint8_t NOTARY_PUBKEY33[33];
 
 BlockMap mapBlockIndex;
 CChain chainActive;
@@ -4974,7 +4975,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     break;
             }
             pfrom->PushMessage("headers", vHeaders);
-        } else fprintf(stderr,"ignore getheaders from peer.%d %d prev.%d\n",(int32_t)pfrom->id,(int32_t)(pindex ? pindex->nHeight : -1),pfrom->lasthdrsreq);
+        }
+        else if ( NOTARY_PUBKEY33[0] != 0 )
+            fprintf(stderr,"you can ignore redundant getheaders from peer.%d %d prev.%d\n",(int32_t)pfrom->id,(int32_t)(pindex ? pindex->nHeight : -1),pfrom->lasthdrsreq);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4965,7 +4965,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         int nLimit = MAX_HEADERS_RESULTS;
         LogPrint("net", "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
         fprintf(stderr,"getheaders from %d prev.%d\n",(int32_t)(pindex ? pindex->nHeight : -1),pfrom->lasthdrsreq);
-        if ( pfrom->lasthdrsreq != (int32_t)(pindex ? pindex->nHeight : -1) )
+        if ( pfrom->lasthdrsreq >= chainActive.Height()-MAX_HEADERS_RESULTS || pfrom->lasthdrsreq != (int32_t)(pindex ? pindex->nHeight : -1) )
         {
             for (; pindex; pindex = chainActive.Next(pindex))
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4498,7 +4498,7 @@ void static ProcessGetData(CNode* pfrom)
                             uint256 hash; int32_t z;
                             hash = block.GetHash();
                             for (z=0; z<32; z++)
-                                printf("%02x",((uint8_t *)&hash)[z]);
+                                fprintf(stderr,"%02x",((uint8_t *)&hash)[z]);
                             fprintf(stderr," send block %d\n",komodo_block2height(&block));
                             pfrom->PushMessage("block", block);
                         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4494,7 +4494,10 @@ void static ProcessGetData(CNode* pfrom)
                     else
                     {
                         if (inv.type == MSG_BLOCK)
+                        {
+                            fprintf(stderr,"send block %d\n",komodo_block2height(&block));
                             pfrom->PushMessage("block", block);
+                        }
                         else // MSG_FILTERED_BLOCK)
                         {
                             LOCK(pfrom->cs_filter);
@@ -4957,6 +4960,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vector<CBlock> vHeaders;
         int nLimit = MAX_HEADERS_RESULTS;
         LogPrint("net", "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
+        fprintf(stderr,"getheaders from %d\n",(int32_t)(pindex ? pindex->nHeight : -1));
         for (; pindex; pindex = chainActive.Next(pindex))
         {
             vHeaders.push_back(pindex->GetBlockHeader());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4497,7 +4497,7 @@ void static ProcessGetData(CNode* pfrom)
                         {
                             uint256 hash; int32_t z;
                             hash = block.GetHash();
-                            for (z=0; z<32; z++)
+                            for (z=31; z>=0; z--)
                                 fprintf(stderr,"%02x",((uint8_t *)&hash)[z]);
                             fprintf(stderr," send block %d\n",komodo_block2height(&block));
                             pfrom->PushMessage("block", block);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4495,11 +4495,11 @@ void static ProcessGetData(CNode* pfrom)
                     {
                         if (inv.type == MSG_BLOCK)
                         {
-                            uint256 hash; int32_t z;
-                            hash = block.GetHash();
-                            for (z=31; z>=0; z--)
-                                fprintf(stderr,"%02x",((uint8_t *)&hash)[z]);
-                            fprintf(stderr," send block %d\n",komodo_block2height(&block));
+                            //uint256 hash; int32_t z;
+                            //hash = block.GetHash();
+                            //for (z=31; z>=0; z--)
+                            //    fprintf(stderr,"%02x",((uint8_t *)&hash)[z]);
+                            //fprintf(stderr," send block %d\n",komodo_block2height(&block));
                             pfrom->PushMessage("block", block);
                         }
                         else // MSG_FILTERED_BLOCK)
@@ -4590,7 +4590,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
-    fprintf(stderr, "recv: %s peer=%d\n", SanitizeString(strCommand).c_str(), (int32_t)pfrom->GetId());
+    //fprintf(stderr, "recv: %s peer=%d\n", SanitizeString(strCommand).c_str(), (int32_t)pfrom->GetId());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");
@@ -4964,7 +4964,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vector<CBlock> vHeaders;
         int nLimit = MAX_HEADERS_RESULTS;
         LogPrint("net", "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
-        fprintf(stderr,"getheaders from %d\n",(int32_t)(pindex ? pindex->nHeight : -1));
+        //fprintf(stderr,"getheaders from %d\n",(int32_t)(pindex ? pindex->nHeight : -1));
         for (; pindex; pindex = chainActive.Next(pindex))
         {
             vHeaders.push_back(pindex->GetBlockHeader());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4583,6 +4583,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
+    fprintf(stderr, "recv: %s (%u bytes) peer=%s\n", SanitizeString(strCommand), vRecv.size(), pfrom->addr.ToString());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4583,7 +4583,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
-    fprintf(stderr, "recv: %s peer=%d\n", SanitizeString(strCommand).c_str(), (itn32_t)pfrom->GetId());
+    fprintf(stderr, "recv: %s peer=%d\n", SanitizeString(strCommand).c_str(), (int32_t)pfrom->GetId());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");

--- a/src/net.h
+++ b/src/net.h
@@ -264,6 +264,7 @@ public:
     std::string addrName;
     CService addrLocal;
     int nVersion;
+    int lasthdrsreq;
     // strSubVer is whatever byte array we read from the wire. However, this field is intended
     // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
     // store the sanitized version in cleanSubVer. The original should be used when dealing with


### PR DESCRIPTION
Workaround for slow windows sync by ignoring redundant get headers requests during sync