### PR TITLE
Read hashReserved block header data from disk

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -302,6 +302,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nUndoPos       = diskindex.nUndoPos;
                 pindexNew->hashAnchor     = diskindex.hashAnchor;
                 pindexNew->nVersion       = diskindex.nVersion;
+                pindexNew->hashReserved   = diskindex.hashReserved;
                 pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;


### PR DESCRIPTION
Related to https://github.com/zcash/zcash/pull/2931 and this bug is known to create sync/banning issues between nodes in various Equihash coins