### PR TITLE
fix OSX deps mk

### DIFF
--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -14,7 +14,8 @@ endif
 ifeq ($(build_os),darwin)
 $(package)_install=ginstall
 define $(package)_build_cmds
-    $(MAKE) -C make gtest.a
+    $(MAKE) -C googlemock/make gmock.a && \
+    $(MAKE) -C googletest/make gtest.a
 endef
 else
 $(package)_install=install

--- a/depends/packages/libsodium.mk
+++ b/depends/packages/libsodium.mk
@@ -1,17 +1,20 @@
+ifeq ($(build_os),darwin)
 package=libsodium
-#<<<<<<< HEAD
-#$(package)_version=1.0.11
-#$(package)_download_path=https://supernetorg.bintray.com/misc
-#$(package)_file_name=libsodium-1.0.11.tar.gz
-#$(package)_sha256_hash=a14549db3c49f6ae2170cbbf4664bd48ace50681045e8dbea7c8d9fb96f9c765
-#=======
+$(package)_version=1.0.11
+$(package)_download_path=https://supernetorg.bintray.com/misc
+$(package)_file_name=libsodium-1.0.11.tar.gz
+$(package)_sha256_hash=a14549db3c49f6ae2170cbbf4664bd48ace50681045e8dbea7c8d9fb96f9c765
+$(package)_dependencies=
+$(package)_config_opts=
+else
+package=libsodium
 $(package)_version=1.0.15
 $(package)_download_path=https://download.libsodium.org/libsodium/releases/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
-#>>>>>>> zcash/master
 $(package)_dependencies=
 $(package)_config_opts=
+endif
 
 define $(package)_preprocess_cmds
   cd $($(package)_build_subdir); ./autogen.sh

--- a/depends/packages/proton.mk
+++ b/depends/packages/proton.mk
@@ -1,6 +1,6 @@
 package=proton
 $(package)_version=0.17.0
-$(package)_download_path=http://apache.cs.utah.edu/qpid/proton/$($(package)_version)
+$(package)_download_path=https://archive.apache.org/dist/qpid/proton/$($(package)_version)
 $(package)_file_name=qpid-proton-$($(package)_version).tar.gz
 $(package)_sha256_hash=6ffd26d3d0e495bfdb5d9fefc5349954e6105ea18cc4bb191161d27742c5a01a
 $(package)_patches=minimal-build.patch
@@ -21,4 +21,3 @@ endef
 define $(package)_stage_cmds
   cd build; $(MAKE) VERBOSE=1 DESTDIR=$($(package)_staging_prefix_dir) install
 endef
-

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,23 +1,16 @@
 package=rust
 $(package)_version=1.16.0
 $(package)_download_path=https://static.rust-lang.org/dist
-#<<<<<<< HEAD
-#ifeq ($(build_os),darwin)
-#$(package)_file_name=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
-#$(package)_sha256_hash=2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926
-#else ifeq ($(host_os),mingw32)
-#$(package)_file_name=rust-$($(package)_version)-i686-unknown-linux-gnu.tar.gz
-#$(package)_sha256_hash=b5859161ebb182d3b75fa14a5741e5de87b088146fb0ef4a30f3b2439c6179c5
-#else
-#$(package)_file_name=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-#$(package)_sha256_hash=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
-#endif
-#=======
-$(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_sha256_hash_linux=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
-$(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
-$(package)_sha256_hash_darwin=2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926
-#>>>>>>> zcash/master
+ifeq ($(build_os),darwin)
+$(package)_file_name=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
+$(package)_sha256_hash=2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926
+else ifeq ($(host_os),mingw32)
+$(package)_file_name=rust-$($(package)_version)-i686-unknown-linux-gnu.tar.gz
+$(package)_sha256_hash=b5859161ebb182d3b75fa14a5741e5de87b088146fb0ef4a30f3b2439c6179c5
+else
+$(package)_file_name=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
+$(package)_sha256_hash=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
+endif
 
 define $(package)_stage_cmds
   ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native --disable-ldconfig


### PR DESCRIPTION
0.17.0 not hosted under legacy URL. moved to apache archive. 
https://github.com/zcash/zcash/commit/2b0e6432fe6170f4dc0d9c0e2f9921d3b3b24880