### PR TITLE
stuck node fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,46 @@
 ## Komodo with Bitcore
 This version of Komodo contains Bitcore support for komodo and all its assetchains.
+
 ## Komodod
 This software is Komodo client, generally you will use this if you want to mine KMD or setup a full node.
 It downloads and stores the entire history of Komodo transactions; depending on the speed of your computer and network connection, the synchronization process could take a day or more once the blockchain has reached a significant size.
+
 ## Development Resources
 - Komodo Web: [https://komodoplatform.com/](https://komodoplatform.com/)
-- Organization web: [https://www.supernet.org](https://www.supernet.org)
-- Forum: [https://forum.supernet.org/](https://forum.supernet.org/)
-- Mail: [info@supernet.org](mailto:info@supernet.org)
-- Support & Guides: [https://support.supernet.org/support/home](https://support.supernet.org/support/home)
+- Organization web: [https://komodoplatform.com/](https://komodoplatform.com/)
+- Forum: [https://forum.komodoplatform.com/](https://forum.komodoplatform.com/)
+- Mail: [info@komodoplatform.com](mailto:info@komodoplatform.com)
+- Support: [https://support.komodoplatform.com/support/home](https://support.komodoplatform.com/support/home)
+- Knowledgebase & How-to: [https://komodoplatform.atlassian.net/wiki/spaces/KPSD/pages](https://komodoplatform.atlassian.net/wiki/spaces/KPSD/pages)
 - API references: [http://docs.supernet.org/](http://docs.supernet.org/) #Not up to date.
+- Whitepaper: [Komodo Whitepaper](https://komodoplatform.com/wp-content/uploads/2018/03/2018-03-12-Komodo-White-Paper-Full.pdf)
 - Komodo Platform public material: [Komodo Platform public material](https://docs.google.com/document/d/1AbhWrtagu4vYdkl-vsWz-HSNyNvK-W-ZasHCqe7CZy0)
+
 ## List of Komodo Platform Technologies
-Delayed Proof of Work (dPoW) - Additional security layer.
-zk-SNARKs - Komodo Platform's privacy technology
-Jumblr - Decentralized tumbler for KMD and other cryptocurrencies
-Assetchains - Easy way to fork Komodo coin
-Pegged Assets - Chains that maintain a peg to fiat currencies
-Peerchains - Scalability solution where sibling chains form a network of blockchains
-More in depth covered [here](https://docs.google.com/document/d/1AbhWrtagu4vYdkl-vsWz-HSNyNvK-W-ZasHCqe7CZy0)
-Also note you receive 5% APR on your holdings.
-[See this article for more details](https://supernet.org/en/resources/articles/receive-free-coins-quaranteed-kmd-interest)
+- Delayed Proof of Work (dPoW) - Additional security layer.
+- zk-SNARKs - Komodo Platform's privacy technology
+- Jumblr - Decentralized tumbler for KMD and other cryptocurrencies
+- Assetchains - Easy way to fork Komodo coin
+- Pegged Assets - Chains that maintain a peg to fiat currencies
+- Peerchains - Scalability solution where sibling chains form a network of blockchains
+- More in depth covered [here](https://docs.google.com/document/d/1AbhWrtagu4vYdkl-vsWz-HSNyNvK-W-ZasHCqe7CZy0)
+- Also note you receive 5% APR on your holdings.
+[See this article for more details](https://komodoplatform.atlassian.net/wiki/spaces/KPSD/pages/20480015/Claim+KMD+Interest+in+Agama)
+
 ## Tech Specification
-Max Supply: 200 million KMD.
-Block Time: 1M 2s
-Block Reward: 3KMD
-Mining Algorithm: Equihash 
+- Max Supply: 200 million KMD.
+- Block Time: 1M 2s
+- Block Reward: 3KMD
+- Mining Algorithm: Equihash 
+
 ## About this Project
 Komodo is based on Zcash and has been  by our innovative consensus algorithm called dPoW which utilizes Bitcoin's hashrate to store Komodo blockchain information into the Bitcoin blockchain. Other new and native Komodo features are the privacy technology called JUMBLR or our assetchain capabilities (one click plug and play blockchain solutions). More details are available under https://komodoplatform.com/. 
+
 ## Getting started
 Dependencies
 ------------
 
-```
+```shell
 #The following packages are needed:
 sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python python-zmq zlib1g-dev wget libcurl4-openssl-dev bsdmainutils automake curl
 ```
@@ -54,7 +62,7 @@ dPoW branch: autobuild into GUI installers, unix, osx, windows
 beta branch: notary nodes, command line unix
 dev branch: bleeding edge, possibly wont even compile, multiple updates per hour
 
-```
+```shell
 git clone https://github.com/jl777/komodo
 cd komodo
 #you might want to: git checkout <branch>; git pull
@@ -63,7 +71,6 @@ cd komodo
 ./zcutil/build.sh -j8
 #This can take some time.
 ```
-
 
 **komodo is experimental and a work-in-progress.** Use at your own risk.
 
@@ -76,11 +83,14 @@ time after this one year period. The automatic feature is based on block
 height and can be explicitly disabled.
 
 
-# to update an existing version, git checkout dPoW if not on that branch already
+# to update an existing version, `git checkout dPoW` if not on that branch already
+```shell
 git pull
 ./zcutil/fetch-params.sh
 ./zcutil/build.sh -j8
-To reset the blockchain, from ~/.komodo rm -rf blocks chainstate debug.log komodostate db.log
+```
+To reset the blockchain, from *~/.komodo* `rm -rf blocks chainstate debug.log komodostate db.log`
+
 Create komodo.conf
 ------------------
 
@@ -105,7 +115,7 @@ addnode=89.248.166.91
 Start mining
 ------------
 
-```
+```shell
 #iguana documentation shows how to get the btcpubkey and wifstrs that need to be used
 #bitcoin also need to be installed with txindex=1 and with rpc enabled
 cd ~
@@ -136,59 +146,88 @@ Both komodod and komodo-cli recognize -ac_name=option so you can create fork fro
 ```
 =======
 **Zcash is unfinished and highly experimental.** Use at your own risk.
+
 Where do I begin?
 -----------------
 We have a guide for joining the main Zcash network:
 https://github.com/zcash/zcash/wiki/1.0-User-Guide
+
 ### Need Help?
 * See the documentation at the [Zcash Wiki](https://github.com/zcash/zcash/wiki)
 for help and more information.
 * Ask for help on the [Zcash](https://forum.z.cash/) forum.
 Participation in the Zcash project is subject to a
 [Code of Conduct](code_of_conduct.md).
+
 Building
 --------
 Build Zcash along with most dependencies from source by running
-./zcutil/build.sh. Currently only Linux is officially supported.
+`./zcutil/build.sh`. Currently only Linux is officially supported.
+
 License
 -------
 For license information see the file [COPYING](COPYING).
-NOTE TO EXCHANGES:
+
+**NOTE TO EXCHANGES:**
 https://bitcointalk.org/index.php?topic=1605144.msg17732151#msg17732151
 There is a small chance that an outbound transaction will give an error due to mismatched values in wallet calculations. There is a -exchange option that you can run komodod with, but make sure to have the entire transaction history under the same -exchange mode. Otherwise you will get wallet conflicts.
-To change modes:
-a) backup all privkeys (launch komodod with -exportdir=<path> and dumpwallet)
-b) start a totally new sync including wallet.dat, launch with same exportdir
-c) stop it before it gets too far and import all the privkeys from a) using komodo-cli importwallet filename
+
+**To change modes:**
+
+a) backup all privkeys (launch komodod with `-exportdir=<path>` and `dumpwallet`)
+  
+b) start a totally new sync including `wallet.dat`, launch with same `exportdir`
+
+c) stop it before it gets too far and import all the privkeys from a) using `komodo-cli importwallet filename`
+
 d) resume sync till it gets to chaintip
+
 For example:
+```shell
 ./komodod -exportdir=/tmp &
 ./komodo-cli dumpwallet example
 ./komodo-cli stop
 mv ~/.komodo ~/.komodo.old && mkdir ~/.komodo && cp ~/.komodo.old/komodo.conf ~/.komodo.old/peers.dat ~/.komodo
 ./komodod -exchange -exportdir=/tmp &
 ./komodo-cli importwallet /tmp/example
-############## JUMBLR
-komodod now has jumblr_deposit and jumblr_secret RPC calls. 
+```
+
+## JUMBLR
+komodod now has `jumblr_deposit` and `jumblr_secret` RPC calls.
+
 Jumblr works like described previously where all the nodes with jumblr active synchronize their tx activity during the same block to maximize the mixing effect. However, unlike all other mixers/tumblers, you never give up control of your coins to anybody else. JUMBLR uses a one to many allocation of funds, ie. one deposit address and many secret addresses. You can always run multiple komodod daemons to get multiple active deposit addresses.
+
 JUMBLR implements t -> z, z -> z and z -> t transactions to maximize privacy of the destination t (transparent) address. So while it is transparent, its first activity is funds coming from an untracable z address.
+
 Which of the three stages is done is randomly selected at each turn. Also when there is more than one possible transaction at the selected stage, a random one is selected. This randomization prevents analyzing incoming z ->t transactions by its size to correlate it to the originating address.
-jumblr_deposit <depositaddr> designates the deposit address as the jumblr deposit address for that session. You can select an address that already has funds in it and it will immediately start jumblr process. If there are no funds, it will wait until you send funds to it.
-There are three sizes of a jumblr transaction: 10 KMD, 100 KMD and 1000 KMD. There is also a fixed interval of blocks where all jumblr nodes are active. Currently it is set to be 10, but this is subject to change. Only during every 10*10 blocks are the largest 1000 KMD transactions processed, so this concentrates all the large transactions every N*N blocks. 
-jumblr_secret <secretaddress> notifies JUMBLR where to send the final z -> t transactions. In order to allow larger accounts to obtain privacy, up to 777 secret addresses are supported. Whenever a z -> t stage is activated, a random secret address from the list of the then active secret addresses is selected.
-Practical Advice:
+
+`jumblr_deposit <depositaddr>` designates the deposit address as the jumblr deposit address for that session. You can select an address that already has funds in it and it will immediately start jumblr process. If there are no funds, it will wait until you send funds to it.
+  
+There are three sizes of a jumblr transaction: 10 KMD, 100 KMD and 1000 KMD. There is also a fixed interval of blocks where all jumblr nodes are active. Currently it is set to be 10, but this is subject to change. Only during every 10*10 blocks are the largest 1000 KMD transactions processed, so this concentrates all the large transactions every N*N blocks.
+
+`jumblr_secret <secretaddress>` notifies JUMBLR where to send the final z -> t transactions. In order to allow larger accounts to obtain privacy, up to 777 secret addresses are supported. Whenever a z -> t stage is activated, a random secret address from the list of the then active secret addresses is selected.
+
+#### Practical Advice:
 Obtaining privacy used to be very difficult. JUMBLR makes it as simple as issuing two command line calls. Higher level layers can be added to help manage the addresses, ie. linking them at the passphrase level. Such matters are left to each implementation.
+
 Once obtained, it is very easy to lose all the privacy. With a single errant transaction that combines some previously used address and the secretaddress, well, the secretaddress is no longer so private.
+
 The advice is to setup a totally separate node!
+
 This might seem a bit drastic, but if you want to maintain privacy, it is best to make it look like all the transactions are coming from a different node. The easiest way for most people to do this is to actually have a different node.
-It can be a dedicated laptop (recommended) or a VPS (for smaller amounts) with a totally fresh komodod wallet. Generate an address on this wallet and use that as the jumblr_secret address on your main node. As the JUMBLR operates funds will teleport into your secret node's address. If you are careful and never use the same IP address for both your nodes, you will be able to maintain very good privacy. 
+
+It can be a dedicated laptop (recommended) or a VPS (for smaller amounts) with a totally fresh komodod wallet. Generate an address on this wallet and use that as the jumblr_secret address on your main node. As the JUMBLR operates funds will teleport into your secret node's address. If you are careful and never use the same IP address for both your nodes, you will be able to maintain very good privacy.
+
 Of course, don't send emails that link the two accounts together! Dont use secret address funds for home delivery purchases! Etc. There are many ways to lose the privacy, just think about what linkages can be dont at the IP and blockchain level and that should be a useful preparation.
+
 What if you have 100,000 KMD and you dont want others to know you are such a whale?
 Instead of generating 1 secret address, generate 100 and make a script file with:
+```shell
 ./komodo-cli jumblr_secret <addr0>
 ./komodo-cli jumblr_secret <addr1>
 ...
 ./komodo-cli jumblr_secret <addr99>
+```
 And make sure to delete all traces of this when the JUMBLR is finished. You will end up with 100 addresses that have an average of 1000 KMD each. So as long as you are careful and dont do a 10,000 KMD transaction (that will link 10 of your secret addresses together), you can appear as 100 different people each with 1000 KMD.
 
 

--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -22,6 +22,7 @@ public:
     MOCK_CONST_METHOD0(GetRejectReason, std::string());
 };
 
+int32_t futureblock;
 TEST(CheckBlock, VersionTooLow) {
     auto verifier = libzcash::ProofVerifier::Strict();
 
@@ -30,7 +31,7 @@ TEST(CheckBlock, VersionTooLow) {
 
     MockCValidationState state;
     EXPECT_CALL(state, DoS(100, false, REJECT_INVALID, "version-too-low", false)).Times(1);
-    EXPECT_FALSE(CheckBlock(0,0,block, state, verifier, false, false));
+    EXPECT_FALSE(CheckBlock(&futureblock,0,0,block, state, verifier, false, false));
 }
 
 

--- a/src/komodo_bitcoind.h
+++ b/src/komodo_bitcoind.h
@@ -1035,7 +1035,7 @@ int32_t komodo_validate_interest(const CTransaction &tx,int32_t txheight,uint32_
                 cmptime -= 16000;
             if ( (int64_t)tx.nLockTime < cmptime-3600 )
             {
-                if ( tx.nLockTime != 1477258935 || dispflag != 0 )
+                if ( tx.nLockTime != 1477258935 && dispflag != 0 )
                 {
                     fprintf(stderr,"komodo_validate_interest.%d reject.%d [%d] locktime %u cmp2.%u\n",dispflag,txheight,(int32_t)(tx.nLockTime - (cmptime-3600)),(uint32_t)tx.nLockTime,cmptime);
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3761,13 +3761,13 @@ bool CheckBlockHeader(int32_t height,CBlockIndex *pindex, const CBlockHeader& bl
     if (blockhdr.GetBlockTime() > GetAdjustedTime() + 60)
     {
         CBlockIndex *tipindex;
-        fprintf(stderr,"ht.%d future block %u vs time.%u + 60\n",height,(uint32_t)blockhdr.GetBlockTime(),(uint32_t)GetAdjustedTime());
+        //fprintf(stderr,"ht.%d future block %u vs time.%u + 60\n",height,(uint32_t)blockhdr.GetBlockTime(),(uint32_t)GetAdjustedTime());
         if ( (tipindex= chainActive.Tip()) != 0 && tipindex->GetBlockHash() == blockhdr.hashPrevBlock && blockhdr.GetBlockTime() < GetAdjustedTime() + 60*2 )
         {
-            fprintf(stderr,"it is the next block, let's wait for %d seconds\n",GetAdjustedTime() + 60 - blockhdr.GetBlockTime());
+            //fprintf(stderr,"it is the next block, let's wait for %d seconds\n",GetAdjustedTime() + 60 - blockhdr.GetBlockTime());
             while ( blockhdr.GetBlockTime() > GetAdjustedTime() + 60 )
                 sleep(1);
-            fprintf(stderr,"now its valid\n");
+            //fprintf(stderr,"now its valid\n");
         }
         else
         {
@@ -4020,7 +4020,7 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
     }
     if (!CheckBlockHeader(*ppindex!=0?(*ppindex)->nHeight:0,*ppindex, block, state,0))
     {
-        fprintf(stderr,"AcceptBlockHeader: CheckBlockHeader failed\n");
+        //fprintf(stderr,"AcceptBlockHeader: CheckBlockHeader failed\n");
         return false;
     }
     // Get prev block index
@@ -4055,7 +4055,7 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
     }
     if (!ContextualCheckBlockHeader(block, state, pindexPrev))
     {
-        fprintf(stderr,"AcceptBlockHeader ContextualCheckBlockHeader failed\n");
+        //fprintf(stderr,"AcceptBlockHeader ContextualCheckBlockHeader failed\n");
         return false;
     }
     if (pindex == NULL)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4123,7 +4123,7 @@ bool AcceptBlock(int32_t *futureblockp,CBlock& block, CValidationState& state, C
     auto verifier = libzcash::ProofVerifier::Disabled();
     if ((!CheckBlock(futureblockp,pindex->nHeight,pindex,block, state, verifier,0)) || !ContextualCheckBlock(block, state, pindex->pprev))
     {
-        if (futureblock == 0 && state.IsInvalid() && !state.CorruptionPossible()) {
+        if (*futureblockp == 0 && state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             setDirtyBlockIndex.insert(pindex);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3759,11 +3759,11 @@ bool CheckBlockHeader(int32_t *futureblockp,int32_t height,CBlockIndex *pindex, 
         }
     }
     *futureblockp = 0;
-    if (blockhdr.GetBlockTime() > GetAdjustedTime() - 60) // test, usually +60
+    if (blockhdr.GetBlockTime() > GetAdjustedTime() + 60)
     {
         CBlockIndex *tipindex;
         fprintf(stderr,"ht.%d future block %u vs time.%u + 60\n",height,(uint32_t)blockhdr.GetBlockTime(),(uint32_t)GetAdjustedTime());
-        if ( 0 && (tipindex= chainActive.Tip()) != 0 && tipindex->GetBlockHash() == blockhdr.hashPrevBlock && blockhdr.GetBlockTime() < GetAdjustedTime() + 60*2 )
+        if ( (tipindex= chainActive.Tip()) != 0 && tipindex->GetBlockHash() == blockhdr.hashPrevBlock && blockhdr.GetBlockTime() < GetAdjustedTime() + 60 + 5 )
         {
             //fprintf(stderr,"it is the next block, let's wait for %d seconds\n",GetAdjustedTime() + 60 - blockhdr.GetBlockTime());
             while ( blockhdr.GetBlockTime() > GetAdjustedTime() + 60 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4033,7 +4033,7 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
         BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
         if (mi == mapBlockIndex.end())
         {
-            fprintf(stderr,"AcceptBlockHeader hashPrevBlock %s not found\n",block.hashPrevBlock.ToString().c_str());
+            //fprintf(stderr,"AcceptBlockHeader hashPrevBlock %s not found\n",block.hashPrevBlock.ToString().c_str());
             /*if ( komodo_requestedhash == zero )
             {
                 komodo_requestedhash = block.hashPrevBlock;
@@ -4119,6 +4119,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     }
     
     // See method docstring for why this is always disabled
+    int32_t futureblock;
     auto verifier = libzcash::ProofVerifier::Disabled();
     if ((!CheckBlock(&futureblock,pindex->nHeight,pindex,block, state, verifier,0)) || !ContextualCheckBlock(block, state, pindex->pprev))
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3999,6 +3999,7 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
     static uint256 zero;
     const CChainParams& chainparams = Params();
     AssertLockHeld(cs_main);
+    int32_t futureblock;
     // Check for duplicate
     uint256 hash = block.GetHash();
     BlockMap::iterator miSelf = mapBlockIndex.find(hash);
@@ -4021,7 +4022,7 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
         //    fprintf(stderr,"accepthdr %s already known but no pindex\n",hash.ToString().c_str());
         return true;
     }
-    if (!CheckBlockHeader(*ppindex!=0?(*ppindex)->nHeight:0,*ppindex, block, state,0))
+    if (!CheckBlockHeader(&futureblock,*ppindex!=0?(*ppindex)->nHeight:0,*ppindex, block, state,0))
     {
         //fprintf(stderr,"AcceptBlockHeader: CheckBlockHeader failed\n");
         return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3759,11 +3759,11 @@ bool CheckBlockHeader(int32_t *futureblockp,int32_t height,CBlockIndex *pindex, 
         }
     }
     *futureblockp = 0;
-    if (blockhdr.GetBlockTime() > GetAdjustedTime() + 60)
+    if (blockhdr.GetBlockTime() > GetAdjustedTime() - 60) // test, usually +60
     {
         CBlockIndex *tipindex;
         fprintf(stderr,"ht.%d future block %u vs time.%u + 60\n",height,(uint32_t)blockhdr.GetBlockTime(),(uint32_t)GetAdjustedTime());
-        if ( (tipindex= chainActive.Tip()) != 0 && tipindex->GetBlockHash() == blockhdr.hashPrevBlock && blockhdr.GetBlockTime() < GetAdjustedTime() + 60*2 )
+        if ( 0 && (tipindex= chainActive.Tip()) != 0 && tipindex->GetBlockHash() == blockhdr.hashPrevBlock && blockhdr.GetBlockTime() < GetAdjustedTime() + 60*2 )
         {
             //fprintf(stderr,"it is the next block, let's wait for %d seconds\n",GetAdjustedTime() + 60 - blockhdr.GetBlockTime());
             while ( blockhdr.GetBlockTime() > GetAdjustedTime() + 60 )

--- a/src/main.h
+++ b/src/main.h
@@ -796,7 +796,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck = false,bool fCheckPOW = false);
 
 /** Context-independent validity checks */
-bool CheckBlockHeader(int32_t height,CBlockIndex *pindex,const CBlockHeader& block, CValidationState& state, bool fCheckPOW = true);
+bool CheckBlockHeader(int32_t *futureblockp,int32_t height,CBlockIndex *pindex,const CBlockHeader& block, CValidationState& state, bool fCheckPOW = true);
 bool CheckBlock(int32_t *futureblockp,int32_t height,CBlockIndex *pindex,const CBlock& block, CValidationState& state,
                 libzcash::ProofVerifier& verifier,
                 bool fCheckPOW = true, bool fCheckMerkleRoot = true);
@@ -815,8 +815,8 @@ bool TestBlockValidity(CValidationState &state, const CBlock& block, CBlockIndex
  * - The only caller of AcceptBlock verifies JoinSplit proofs elsewhere.
  * If dbp is non-NULL, the file is known to already reside on disk
  */
-bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex **pindex, bool fRequested, CDiskBlockPos* dbp);
-bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex **ppindex= NULL);
+bool AcceptBlock(int32_t *futureblockp,CBlock& block, CValidationState& state, CBlockIndex **pindex, bool fRequested, CDiskBlockPos* dbp);
+bool AcceptBlockHeader(int32_t *futureblockp,const CBlockHeader& block, CValidationState& state, CBlockIndex **ppindex= NULL);
 
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -797,7 +797,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
 /** Context-independent validity checks */
 bool CheckBlockHeader(int32_t height,CBlockIndex *pindex,const CBlockHeader& block, CValidationState& state, bool fCheckPOW = true);
-bool CheckBlock(int32_t height,CBlockIndex *pindex,const CBlock& block, CValidationState& state,
+bool CheckBlock(int32_t *futureblockp,int32_t height,CBlockIndex *pindex,const CBlock& block, CValidationState& state,
                 libzcash::ProofVerifier& verifier,
                 bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -401,15 +401,19 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
     }
 }
 
+int32_t komodo_validate_interest(const CTransaction &tx,int32_t txheight,uint32_t nTime,int32_t dispflag);
+
 void CTxMemPool::removeExpired(unsigned int nBlockHeight)
 {
+    CBlockIndex *tipindex;
     // Remove expired txs from the mempool
     LOCK(cs);
     list<CTransaction> transactionsToRemove;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
     {
         const CTransaction& tx = it->GetTx();
-        if (IsExpiredTx(tx, nBlockHeight) || komodo_validate_interest(tx,chainActive.Tip()->nHeight+1,chainActive.Tip()->GetMedianTimePast() + 777,0) < 0)
+        tipindex = chainActive.Tip();
+        if (IsExpiredTx(tx, nBlockHeight) || (tipindex != 0 && komodo_validate_interest(tx,tipindex->nHeight+1,tipindex->GetMedianTimePast() + 777,1) < 0)
         {
             transactionsToRemove.push_back(tx);
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -413,7 +413,7 @@ void CTxMemPool::removeExpired(unsigned int nBlockHeight)
     {
         const CTransaction& tx = it->GetTx();
         tipindex = chainActive.Tip();
-        if (IsExpiredTx(tx, nBlockHeight) || (tipindex != 0 && komodo_validate_interest(tx,tipindex->nHeight+1,tipindex->GetMedianTimePast() + 777,1) < 0)
+        if (IsExpiredTx(tx, nBlockHeight) || (tipindex != 0 && komodo_validate_interest(tx,tipindex->nHeight+1,tipindex->GetMedianTimePast() + 777,1)) < 0)
         {
             transactionsToRemove.push_back(tx);
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -409,7 +409,8 @@ void CTxMemPool::removeExpired(unsigned int nBlockHeight)
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
     {
         const CTransaction& tx = it->GetTx();
-        if (IsExpiredTx(tx, nBlockHeight)) {
+        if (IsExpiredTx(tx, nBlockHeight) || komodo_validate_interest(tx,chainActive.Tip()->nHeight+1,chainActive.Tip()->GetMedianTimePast() + 777,0) < 0)
+        {
             transactionsToRemove.push_back(tx);
         }
     }


### PR DESCRIPTION
The timestamp variability created a condition where depending on the system clock and the clock offset of a particular node, to mark as invalid a block that was actually valid.

The old rule was if a block that had a timestamp 60 seconds in the future came in to mark it as invalid and it would never be allowed in the chain (until you restart).

The new rule is to do a “soft” reject and just not process it, i.e. not invalidating it for the duration of the process.

It was a rare condition, but I verified it with a special version that pretended all blocks were from the future.