### PR TITLE
Remove VOTE2018 from `fiat-cli`

### DIFF
--- a/src/fiat-cli
+++ b/src/fiat-cli
@@ -22,7 +22,6 @@ echo etomic; fiat/etomic $1 $2 $3 $4
 echo btch; fiat/btch $1 $2 $3 $4
 echo pizza; fiat/pizza $1 $2 $3 $4
 echo beer; fiat/beer $1 $2 $3 $4
-echo vote2018; fiat/vote2018 $1 $2 $3 $4
 echo ninja; fiat/ninja $1 $2 $3 $4
 echo oot; fiat/oot $1 $2 $3 $4
 echo bntn; fiat/bntn $1 $2 $3 $4


### PR DESCRIPTION
The VOTE2018 asset chain has been removed:

https://github.com/jl777/komodo/commit/3611134826b08ded4aec2a15a3e602a3451fa64c
https://github.com/jl777/komodo/commit/872338fa62f10bd4c664405736c75e675ce69014
https://github.com/jl777/komodo/commit/b79d1ecda5e35daa08c00e53cf1cd95028b155eb
https://github.com/jl777/komodo/commit/6ff3cabc314232f30addf6dbbde08a1f7d5d482a

However the call to it's (now removed) cli wrapper script wasn't removed from `fiat-cli` so any call to `fiat-cli` would return errors about missing files.