### PR TITLE
Regtest mode for Komodo

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -532,11 +532,13 @@ public:
         BOOST_STATIC_ASSERT(equihash_parameters_acceptable(N, K));
         nEquihashN = N;
         nEquihashK = K;
-        genesis.nTime = 1296688602;
+        genesis.nTime = 1519568466;
         genesis.nBits = KOMODO_MINDIFF_NBITS;
-        genesis.nNonce = uint256S("0x0000000000000000000000000000000000000000000000000000000000000021");
-        genesis.nSolution = ParseHex("0f2a976db4c4263da10fd5d38eb1790469cf19bdb4bf93450e09a72fdff17a3454326399");
+        genesis.nNonce = uint256S("0x0000000000000000000000000000000000000000000000000000000000000016");
+        genesis.nSolution = ParseHex("0d1d1ef025037da781252f695ff279c12d492c5ed53e565c8ecdc044ede53cea96cff5fc");
         consensus.hashGenesisBlock = genesis.GetHash();
+        assert(consensus.hashGenesisBlock == uint256S("0x0379ff1530af893f2f2e61146db6e900dd828dc8254215b9de23df2dba06664f"));
+
         nDefaultPort = 17779;
         nPruneAfterHeight = 1000;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -537,7 +537,7 @@ public:
             1296688602,
             uint256S("0x0000000000000000000000000000000000000000000000000000000000000009"),
             ParseHex("01936b7db1eb4ac39f151b8704642d0a8bda13ec547d54cd5e43ba142fc6d8877cab07b3"),
-            0x200f0f0f, 4, 0);
+            KOMODO_MINDIFF_NBITS, 4, 0);
         consensus.hashGenesisBlock = genesis.GetHash();
         assert(consensus.hashGenesisBlock == uint256S("0x029f11d80ef9765602235e1bc9727e3eb6ba20839319f761fee920d63401e327"));
         assert(genesis.hashMerkleRoot == uint256S("0xc4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"));

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -532,18 +532,15 @@ public:
         BOOST_STATIC_ASSERT(equihash_parameters_acceptable(N, K));
         nEquihashN = N;
         nEquihashK = K;
-        // #define KOMODO_MINDIFF_NBITS 0x200f0f0f
+
         genesis = CreateGenesisBlock(
             1296688602,
-            uint256S("0x000000000000000000000000000000000000000000000000000000000000002f"),
-            ParseHex("1d64134e87a42ad5f12196da1452cb56b1f22a438fabd776ee8fca71ce1fb9b7fcc6f5ec"),
-            KOMODO_MINDIFF_NBITS, 4, 0);
-
+            uint256S("0x0000000000000000000000000000000000000000000000000000000000000009"),
+            ParseHex("01936b7db1eb4ac39f151b8704642d0a8bda13ec547d54cd5e43ba142fc6d8877cab07b3"),
+            0x200f0f0f, 4, 0);
         consensus.hashGenesisBlock = genesis.GetHash();
-        printf("genblock hash=%s\n", consensus.hashGenesisBlock.ToString().c_str() );
-        assert(consensus.hashGenesisBlock == uint256S("0xe76fb931218cd30c8bc6e6dfe26925eeff7611c7e6957466ea0d38cde03f0008"));
-        //assert(consensus.hashGenesisBlock == uint256S("0x02dd14e268a4b7a7e6758f14e718abf82cc6649e53bf00bace3059a74d66ec79"));
-        //TODO: assert merkle root
+        assert(consensus.hashGenesisBlock == uint256S("0x029f11d80ef9765602235e1bc9727e3eb6ba20839319f761fee920d63401e327"));
+        assert(genesis.hashMerkleRoot == uint256S("0xc4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"));
 
         nDefaultPort = 17779;
         nPruneAfterHeight = 1000;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -532,12 +532,15 @@ public:
         BOOST_STATIC_ASSERT(equihash_parameters_acceptable(N, K));
         nEquihashN = N;
         nEquihashK = K;
-        genesis.nTime = 1519568466;
-        genesis.nBits = KOMODO_MINDIFF_NBITS;
-        genesis.nNonce = uint256S("0x0000000000000000000000000000000000000000000000000000000000000016");
-        genesis.nSolution = ParseHex("0d1d1ef025037da781252f695ff279c12d492c5ed53e565c8ecdc044ede53cea96cff5fc");
+        genesis = CreateGenesisBlock(
+            1519568466,
+            uint256S("0x0000000000000000000000000000000000000000000000000000000000000016"),
+            ParseHex("0d1d1ef025037da781252f695ff279c12d492c5ed53e565c8ecdc044ede53cea96cff5fc"),
+            KOMODO_MINDIFF_NBITS, 4, 0);
+
         consensus.hashGenesisBlock = genesis.GetHash();
         assert(consensus.hashGenesisBlock == uint256S("0x0379ff1530af893f2f2e61146db6e900dd828dc8254215b9de23df2dba06664f"));
+        //TODO: assert merkle root
 
         nDefaultPort = 17779;
         nPruneAfterHeight = 1000;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -532,14 +532,17 @@ public:
         BOOST_STATIC_ASSERT(equihash_parameters_acceptable(N, K));
         nEquihashN = N;
         nEquihashK = K;
+        // #define KOMODO_MINDIFF_NBITS 0x200f0f0f
         genesis = CreateGenesisBlock(
-            1519568466,
-            uint256S("0x0000000000000000000000000000000000000000000000000000000000000016"),
-            ParseHex("0d1d1ef025037da781252f695ff279c12d492c5ed53e565c8ecdc044ede53cea96cff5fc"),
+            1296688602,
+            uint256S("0x000000000000000000000000000000000000000000000000000000000000002f"),
+            ParseHex("1d64134e87a42ad5f12196da1452cb56b1f22a438fabd776ee8fca71ce1fb9b7fcc6f5ec"),
             KOMODO_MINDIFF_NBITS, 4, 0);
 
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x0379ff1530af893f2f2e61146db6e900dd828dc8254215b9de23df2dba06664f"));
+        printf("genblock hash=%s\n", consensus.hashGenesisBlock.ToString().c_str() );
+        assert(consensus.hashGenesisBlock == uint256S("0xe76fb931218cd30c8bc6e6dfe26925eeff7611c7e6957466ea0d38cde03f0008"));
+        //assert(consensus.hashGenesisBlock == uint256S("0x02dd14e268a4b7a7e6758f14e718abf82cc6649e53bf00bace3059a74d66ec79"));
         //TODO: assert merkle root
 
         nDefaultPort = 17779;


### PR DESCRIPTION
This ports regtest params from latest Zcash upstream. I tried Hush first, but it is just behind KMD in tracking Zcash upstream and has not pulled in various consensus internal parameter changes, which effect the hashes.

Here is regtest mode loading it's block index:

```
2018-05-19 17:50:55 LoadBlockIndexDB: start loading guts
2018-05-19 17:50:55 LoadBlockIndexDB: loaded guts
2018-05-19 17:50:55 LoadBlockIndexDB: last block file = 0
2018-05-19 17:50:55 LoadBlockIndexDB: last block file info: CBlockFileInfo(blocks=1, size=390, heights=0...0, time=2011-02-02...2011-02-02)
2018-05-19 17:50:55 Checking all blk files are present...
2018-05-19 17:50:55 LoadBlockIndexDB: transaction index enabled
2018-05-19 17:50:55 LoadBlockIndexDB: address index disabled
2018-05-19 17:50:55 LoadBlockIndexDB: timestamp index disabled
2018-05-19 17:50:55 LoadBlockIndexDB: spent index disabled
2018-05-19 17:50:55 LoadBlockIndexDB: hashBestChain=029f11d80ef9765602235e1bc9727e3eb6ba20839319f761fee920d63401e327 height=0 date=2011-02-02 23:16:42 progress=1.000000
```

and this Gist shows an RPC method being called to verify we are in regtest mode:

https://gist.github.com/leto/b72b2df9127c7a6703dba2fb06038b16

There seems to be a bug in actually generating new blocks in regtest mode, I get a coredump when running `./komodo-cli -regtest generate 101`, so I am handing off to @jl777 to dive into that 🙈 

```
[] PASSPORT iteration waiting for KOMODO_INITDONE
inds.0x10a8c5000 validate /Users/jonathanleto/Library/Application Support/Komodo/komodostate.ind fsize.6098760 datalen.90973077 n.1524690 lastfpos.0
/Users/jonathanleto/Library/Application Support/Komodo/komodostate.ind validated fpos.90973077
took 8 seconds to process /Users/jonathanleto/Library/Application Support/Komodo/komodostate 88840KB
READY for  RPC calls at 1526751948! done PASSPORT  refid.33

Segmentation fault: 11 (core dumped)
```
