### PR TITLE
Fix the importing and exporting of viewing keys on mainnet + testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -173,6 +173,8 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
         // guarantees the first two characters, when base58 encoded, are "zc"
         base58Prefixes[ZCPAYMENT_ADDRRESS] = {22,154};
+        // guarantees the first 4 characters, when base58 encoded, are "ZiVK"
+        base58Prefixes[ZCVIEWING_KEY]      = {0xA8,0xAB,0xD3};
         // guarantees the first two characters, when base58 encoded, are "SK"
         base58Prefixes[ZCSPENDING_KEY] = {171,54};
 
@@ -467,6 +469,8 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[ZCPAYMENT_ADDRRESS] = {20,81};
+        // guarantees the first 4 characters, when base58 encoded, are "ZiVt"
+        base58Prefixes[ZCVIEWING_KEY]  = {0xA8,0xAC,0x0C};
         base58Prefixes[ZCSPENDING_KEY] = {177,235};
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));


### PR DESCRIPTION
It turns out that `ZCVIEWING_KEY` was only defined on regtest, and that it not being defined on mainnet/testnet was not detected. Implicitly "the empty prefix" was used, which lead to viewing keys without the normal "ZiVK" prefix which were not of the expected size, which finally fails this size check in base58.cpp : 

```
template<class DATA_TYPE, CChainParams::Base58Type PREFIX, size_t SER_SIZE>
DATA_TYPE CZCEncoding<DATA_TYPE, PREFIX, SER_SIZE>::Get() const
{
    if (vchData.size() != SER_SIZE) {
        throw std::runtime_error(
            PrependName(" is invalid")
        );
    }
```

This shows a viewing key being successfully exported on one machine and imported on another, both machines running this branch: 
```
(loki)(~/git/komodo dev *$%= )$ ./src/komodo-cli z_exportviewingkey zcGfyhUgaC8oKhqAR95Nhb2NhpMSe5HqKXSG44GqTDK93yK2updyMispv2s6iwmqKsG7L24emgMGAHtmnMsiT9V4ooqoKh7
ZiVKWkm4XcA5AKZyGqN3rn3iipmgwNeBWM138p1f8EJytZMQzkPdRcTKMEf62ymocxab5rLSJdmZAKF4VZxCLaNoaC7edbWiw

hush@stilgar:~/git/komodo$ ./src/komodo-cli z_importviewingkey ZiVKWkm4XcA5AKZyGqN3rn3iipmgwNeBWM138p1f8EJytZMQzkPdRcTKMEf62ymocxab5rLSJdmZAKF4VZxCLaNoaC7edbWiw no

hush@stilgar:~/git/komodo$ ./src/komodo-cli z_validateaddress zcGfyhUgaC8oKhqAR95Nhb2NhpMSe5HqKXSG44GqTDK93yK2updyMispv2s6iwmqKsG7L24emgMGAHtmnMsiT9V4ooqoKh7
{
  "isvalid": true,
  "address": "zcGfyhUgaC8oKhqAR95Nhb2NhpMSe5HqKXSG44GqTDK93yK2updyMispv2s6iwmqKsG7L24emgMGAHtmnMsiT9V4ooqoKh7",
  "payingkey": "...",
  "transmissionkey": "....",
  "ismine": false
}
```

The `ismine: false` above means that the address had a viewing key imported.

