### PR TITLE
Jl777

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4065,7 +4065,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         CBlockIndex* pcheckpoint = Checkpoints::GetLastCheckpoint(chainParams.Checkpoints());
         int32_t notarized_height;
         if ( nHeight == 1 && chainActive.Tip() != 0 && chainActive.Tip()->nHeight > 1 )
-            return(false)
+            return(false);
         if ( nHeight != 0 )
         {
             if ( pcheckpoint != 0 && nHeight < pcheckpoint->nHeight )


### PR DESCRIPTION
two fixes for eval.h so it compiles on older gcc and prevent an overflow

KV syncs from scratch