### PR TITLE
Fix progress estimate for asset chains in UpdateTip

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3199,7 +3199,8 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     if ( ASSETCHAINS_SYMBOL[0] == 0 ) {
         progress = Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip());
     } else {
-        progress = (KOMODO_LONGESTCHAIN > 0 ) ? chainActive.Height() / KOMODO_LONGESTCHAIN : 1.0;
+	int32_t longestchain = komodo_longestchain();
+	progress = (longestchain > 0 ) ? (double) chainActive.Height() / longestchain : 1.0;
     }
 
     LogPrintf("%s: new best=%s  height=%d  log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%utx)\n", __func__,
@@ -4858,11 +4859,21 @@ bool static LoadBlockIndexDB()
     it->second->hashAnchorEnd = pcoinsTip->GetBestAnchor();
     
     PruneBlockIndexCandidates();
+
+    double progress;
+    if ( ASSETCHAINS_SYMBOL[0] == 0 ) {
+        progress = Checkpoints::GuessVerificationProgress(chainparams.Checkpoints(), chainActive.Tip());
+    } else {
+	int32_t longestchain = komodo_longestchain();
+	// TODO: komodo_longestchain does not have the data it needs at the time LoadBlockIndexDB
+	// runs, which makes it return 0, so we guess 50% for now
+	progress = (longestchain > 0 ) ? (double) chainActive.Height() / longestchain : 0.5;
+    }
     
     LogPrintf("%s: hashBestChain=%s height=%d date=%s progress=%f\n", __func__,
               chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(),
               DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
-              Checkpoints::GuessVerificationProgress(chainparams.Checkpoints(), chainActive.Tip()));
+	      progress);
     
     EnforceNodeDeprecation(chainActive.Height(), true);
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3195,10 +3195,18 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     nTimeBestReceived = GetTime();
     mempool.AddTransactionsUpdated(1);
     KOMODO_NEWBLOCKS++;
+    double progress;
+    if ( ASSETCHAINS_SYMBOL[0] == 0 ) {
+        progress = Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip());
+    } else {
+        progress = (KOMODO_LONGESTCHAIN > 0 ) ? chainActive.Height() / KOMODO_LONGESTCHAIN : 1.0;
+    }
+
     LogPrintf("%s: new best=%s  height=%d  log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%utx)\n", __func__,
-              chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
-              DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
-              Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
+              chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(),
+              log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
+              DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()), progress,
+              pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
     
     cvBlockChange.notify_all();
     


### PR DESCRIPTION
This fixes progress estimate in UpdateTip for all asset chains and adds the necessary code to LoadBlockIndexDB.

I could not get `komodo_longestchain()` to return anything but 0 during LoadBlockIndexDB, it doesn't seem to have the data it needs yet, so currently the code below guesses 50%.

This was tested on the AXO ac:

```
2018-07-16 07:10:35 UpdateTip: new best=0354cb20bca6275724e4041f5b53f086423978d8d4cddc903557728299079e11  height=9171  log2_work=17.294414  tx=22838  date=2018-07-16 07:06:01 progress=0.999891  cache=13.1MiB(11768tx)
2018-07-16 07:10:35 UpdateTip: new best=00e0065b6d00ee4052fe3d8aa09db0d8e02721d6fe544f061cf34a8675bc568a  height=9172  log2_work=17.294567  tx=22840  date=2018-07-16 07:06:55 progress=1.000000  cache=13.1MiB(11770tx)
```
