### PR TITLE
getsnapshot RPC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -590,10 +590,18 @@ CBlockTreeDB *pblocktree = NULL;
 
 int64_t komodo_snapshot()
 {
+    fprintf(stderr,"komodo_snapshot\n");
     int64_t total = -1;
-    if ( pblocktree != 0 )
-        total = pblocktree->Snapshot();
-    else fprintf(stderr,"null pblocktree start with -addressindex=true\n");
+    if (fAddressIndex) {
+	    if ( pblocktree != 0 ) {
+		total = pblocktree->Snapshot();
+	    } else {
+		fprintf(stderr,"null pblocktree start with -addressindex=true\n");
+	    }
+    } else {
+	    fprintf(stderr,"getsnapshot requires -addressindex=true\n");
+    }
+    fprintf(stderr,"total=%li\n", total);
     return(total);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -592,6 +592,7 @@ UniValue komodo_snapshot()
 {
     int64_t total = -1;
     UniValue result(UniValue::VOBJ);
+
     if (fAddressIndex) {
 	    if ( pblocktree != 0 ) {
 		result = pblocktree->Snapshot();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -590,6 +590,7 @@ CBlockTreeDB *pblocktree = NULL;
 
 UniValue komodo_snapshot()
 {
+    LOCK(cs_main);
     int64_t total = -1;
     UniValue result(UniValue::VOBJ);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -588,21 +588,20 @@ CBlockTreeDB *pblocktree = NULL;
 #define KOMODO_ZCASH
 #include "komodo.h"
 
-int64_t komodo_snapshot()
+UniValue komodo_snapshot()
 {
-    fprintf(stderr,"komodo_snapshot\n");
     int64_t total = -1;
+    UniValue result(UniValue::VOBJ);
     if (fAddressIndex) {
 	    if ( pblocktree != 0 ) {
-		total = pblocktree->Snapshot();
+		result = pblocktree->Snapshot();
 	    } else {
 		fprintf(stderr,"null pblocktree start with -addressindex=true\n");
 	    }
     } else {
 	    fprintf(stderr,"getsnapshot requires -addressindex=true\n");
     }
-    fprintf(stderr,"total=%li\n", total);
-    return(total);
+    return(result);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -1015,7 +1015,7 @@ UniValue getaddressbalance(const UniValue& params, bool fHelp)
 
 }
 
-int32_t komodo_snapshot();
+UniValue komodo_snapshot();
 
 UniValue getsnapshot(const UniValue& params, bool fHelp)
 {
@@ -1026,9 +1026,13 @@ UniValue getsnapshot(const UniValue& params, bool fHelp)
                             "getsnapshot\n"
                             );
     }
-    if ( (total= komodo_snapshot()) >= 0 )
-        result.push_back(Pair("total", (double)total/COIN));
-    else result.push_back(Pair("error", "no addressindex"));
+    result = komodo_snapshot();
+    if ( result.size() > 0 ) {
+	// add timestamp, maybe block height?
+        result.push_back(Pair("time", time(NULL)));
+    } else {
+	result.push_back(Pair("error", "no addressindex"));
+    }
     return(result);
 }
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -1028,8 +1028,7 @@ UniValue getsnapshot(const UniValue& params, bool fHelp)
     }
     result = komodo_snapshot();
     if ( result.size() > 0 ) {
-	// add timestamp, maybe block height?
-        result.push_back(Pair("time", time(NULL)));
+        result.push_back(Pair("end_time", time(NULL)));
     } else {
 	result.push_back(Pair("error", "no addressindex"));
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -435,7 +435,7 @@ extern UniValue CBlockTreeDB::Snapshot()
 		    std::map <std::string, CAmount>::iterator pos = addressAmounts.find(address);
 		    if (pos == addressAmounts.end()) {
 			// insert new address + utxo amount
-			fprintf(stderr, "inserting new address %s with amount %li\n", address.c_str(), nValue);
+			//fprintf(stderr, "inserting new address %s with amount %li\n", address.c_str(), nValue);
 			addressAmounts[address] = nValue;
 			totalAddresses++;
 		    } else {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -405,17 +405,12 @@ extern UniValue CBlockTreeDB::Snapshot()
     boost::scoped_ptr<leveldb::Iterator> pcursor(NewIterator());
     std::map <std::string, CAmount> addressAmounts;
     UniValue result(UniValue::VOBJ);
+    result.push_back(Pair("start_time", time(NULL)));
 
     //pcursor->SeekToFirst();
     pcursor->SeekToLast();
 
     int64_t startingHeight = chainActive.Height();
-
-    // prevent any node updates so we can get a consistent snapshot at this height
-    //  causes coredumps
-    // LOCK(cs_main);
-    //  does not compile
-    //LOCK(cs_wallet);
 
     while (pcursor->Valid())
     {
@@ -476,12 +471,8 @@ extern UniValue CBlockTreeDB::Snapshot()
     for (std::pair<std::string, CAmount> element : sortedSnapshot) {
 	UniValue obj(UniValue::VOBJ);
 	obj.push_back( make_pair("addr", element.first.c_str() ) );
-	std::ostringstream strs;
-	strs << ((double) element.second/COIN);
-	std::string amount = strs.str();
-
-	//std::string amount = boost::lexical_cast<std::string>((double) element.second/COIN);
-	//sprintf(amount, "%.8f", (double) element.second / COIN);
+	char amount[32];
+	sprintf(amount, "%.8f", (double) element.second / COIN);
 	obj.push_back( make_pair("amount", amount) );
 	addressesSorted.push_back(obj);
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -454,15 +454,23 @@ extern UniValue CBlockTreeDB::Snapshot()
         pcursor->Prev();
     }
 
-   // TODO: create addresses key with array of {address,amount} 
+    UniValue addresses(UniValue::VARR);
 
     fprintf(stderr, "total=%f, totalAddresses=%li\n", (double) total / COIN, totalAddresses);
     for (map <std::string, CAmount>::iterator it = addressAmounts.begin(); it != addressAmounts.end(); it++)
     {
-        fprintf(stderr,"{\"%s\", %.8f},\n",it->first.c_str(),(double) it->second / COIN);
-        result.push_back(make_pair( it->first.c_str(), (double) it->second / COIN ) );
+        UniValue obj(UniValue::VOBJ);
+	fprintf(stderr,"{\"%s\", %.8f},\n",it->first.c_str(),(double) it->second / COIN);
+	obj.push_back( make_pair("addr", it->first.c_str() ) );
+	obj.push_back( make_pair("amount", (double) it->second / COIN));
+	addresses.push_back(obj);
     }
 
+    result.push_back(make_pair("addresses", addresses));
+    result.push_back(make_pair("total", total / COIN ));
+    result.push_back(make_pair("average",(double) (total/COIN) / totalAddresses ));
+    result.push_back(make_pair("total_addresses", totalAddresses));
+    result.push_back(make_pair("height", chainActive.Height()));
     return(result);
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <univalue.h>
 
 class CBlockFileInfo;
 class CBlockIndex;
@@ -94,7 +95,7 @@ public:
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts();
     bool blockOnchainActive(const uint256 &hash);
-    int64_t Snapshot();
+    UniValue Snapshot();
 };
 
 #endif // BITCOIN_TXDB_H


### PR DESCRIPTION
This finds all unspent outputs for every address in the address index, and dumps them as a snapshot JSON structure that will make airdropping/snapshotting chains as simple as a single RPC call.

The data looks like:

```
  "addresses": [
    {
      "addr": "RLr1rcn46FtwXsc9RBwRCkSabFsLTKKwjm",
      "amount": "7482712.09270000"
    },
    {
      "addr": "RLjfTaeuE4mS1aLE2TJG8tuBCC8uuauFGP",
      "amount": "3500000.00000000"
    },
```

It returns a sorted list of addresses (rich-list) and also some metadata about the dataset:

```
  "total": 11000000,
  "average": 2110.919209364805,
  "total_addresses": 5211,
  "start_height": 12611,
  "ending_height": 12611,
  "end_time": 1531867163,
  "end_time": 1531867164
```

This process scales with the number of UTXOs in the chain, not the number of addresses in the snapshot. To snapshot the entire ZILLA chain (just over 5000 addresses) at the current block height it took about 0.3 seconds:

```
 time ./fiat/zilla getsnapshot > zilla.json

real    0m0.348s
user    0m0.000s
sys     0m0.000s
```

