### PR TITLE
fix for invalid lambda cast in CCcustom

### DIFF
--- a/src/cc/CCcustom.inc
+++ b/src/cc/CCcustom.inc
@@ -5,7 +5,7 @@ bool FUNCNAME(CScript const& scriptSig)
     if (!(cond = GetCryptoCondition(scriptSig)))
         return false;
     // Recurse the CC tree to find asset condition
-    auto findEval = [&] (CC *cond, struct CCVisitor _) {
+    auto findEval = [] (CC *cond, struct CCVisitor _) {
     bool r = cc_typeId(cond) == CC_Eval && cond->codeLength == 1 && cond->code[0] == EVALCODE;
     // false for a match, true for continue
     return r ? 0 : 1;


### PR DESCRIPTION
Fixes compilation on later versions of GCC. Shouldn't have worked anyway really.