### PR TITLE
Fix compiler error: call of overloaded 'Pair(const char [9], time_t)'…

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -1028,7 +1028,7 @@ UniValue getsnapshot(const UniValue& params, bool fHelp)
     }
     result = komodo_snapshot();
     if ( result.size() > 0 ) {
-        result.push_back(Pair("end_time", time(NULL)));
+        result.push_back(Pair("end_time", (int) time(NULL)));
     } else {
 	result.push_back(Pair("error", "no addressindex"));
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -407,7 +407,7 @@ extern UniValue CBlockTreeDB::Snapshot()
     std::map <std::string, CAmount> addressAmounts;
     std::vector <std::pair<CAmount, std::string>> vaddr;
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("start_time", time(NULL)));
+    result.push_back(Pair("start_time", (int) time(NULL)));
 
     std::map <std::string,int> ignoredMap = {
 	{"RReUxSs5hGE39ELU23DfydX8riUuzdrHAE", 1},


### PR DESCRIPTION
Fixes

```
rpcmisc.cpp: In function 'UniValue getsnapshot(const UniValue&, bool)':
rpcmisc.cpp:1031:53: error: call of overloaded 'Pair(const char [9], time_t)' is ambiguous
         result.push_back(Pair("end_time", time(NULL)));
```

on gcc 6 on OS X:
```
Using built-in specs.
COLLECT_GCC=gcc-6
COLLECT_LTO_WRAPPER=/usr/local/Cellar/gcc@6/6.4.0_2/libexec/gcc/x86_64-apple-darwin17.3.0/6.4.0/lto-wrapper
Target: x86_64-apple-darwin17.3.0
Configured with: ../configure --build=x86_64-apple-darwin17.3.0 --prefix=/usr/local/Cellar/gcc@6/6.4.0_2 --libdir=/usr/local/Cellar/gcc@6/6.4.0_2/lib/gcc/6 --enable-languages=c,c++,objc,obj-c++,fortran --program-suffix=-6 --with-gmp=/usr/local/opt/gmp --with-mpfr=/usr/local/opt/mpfr --with-mpc=/usr/local/opt/libmpc --with-isl=/usr/local/opt/isl --with-system-zlib --enable-stage1-checking --enable-checking=release --enable-lto --with-build-config=bootstrap-debug --disable-werror --with-pkgversion='Homebrew GCC 6.4.0_2' --with-bugurl=https://github.com/Homebrew/homebrew-core/issues --disable-nls --enable-multilib
Thread model: posix
gcc version 6.4.0 (Homebrew GCC 6.4.0_2)
```

