### PR TITLE
Fix crash1 osx

### DIFF
--- a/src/cryptoconditions/src/cryptoconditions.c
+++ b/src/cryptoconditions/src/cryptoconditions.c
@@ -29,11 +29,7 @@
 #include "src/json_rpc.c"
 #include <cJSON.h>
 
-#ifdef __LP64__
 #include <stdlib.h>
-#else
-#include <malloc.h>            // Index into CTransaction.vjoinsplit
-#endif
 
 
 struct CCType *CCTypeRegistry[] = {
@@ -199,7 +195,7 @@ CC *fulfillmentToCC(Fulfillment_t *ffill) {
 
 CC *cc_readFulfillmentBinary(const unsigned char *ffill_bin, size_t ffill_bin_len) {
     CC *cond = 0;
-    unsigned char *buf = malloc(ffill_bin_len);
+    unsigned char *buf = calloc(1,ffill_bin_len);
     Fulfillment_t *ffill = 0;
     asn_dec_rval_t rval = ber_decode(0, &asn_DEF_Fulfillment, (void **)&ffill, ffill_bin, ffill_bin_len);
     if (rval.code != RC_OK) {

--- a/src/cryptoconditions/src/ed25519.c
+++ b/src/cryptoconditions/src/ed25519.c
@@ -62,7 +62,7 @@ static int ed25519Sign(CC *cond, CCVisitor visitor) {
     if (cond->type->typeId != CC_Ed25519Type.typeId) return 1;
     CCEd25519SigningData *signing = (CCEd25519SigningData*) visitor.context;
     if (0 != memcmp(cond->publicKey, signing->pk, 32)) return 1;
-    if (!cond->signature) cond->signature = malloc(64);
+    if (!cond->signature) cond->signature = calloc(1,64);
     ed25519_sign(cond->signature, visitor.msg, visitor.msgLength,
             signing->pk, signing->skpk);
     signing->nSigned++;
@@ -141,9 +141,9 @@ static void ed25519ToJSON(const CC *cond, cJSON *params) {
 
 static CC *ed25519FromFulfillment(const Fulfillment_t *ffill) {
     CC *cond = cc_new(CC_Ed25519);
-    cond->publicKey = malloc(32);
+    cond->publicKey = calloc(1,32);
     memcpy(cond->publicKey, ffill->choice.ed25519Sha256.publicKey.buf, 32);
-    cond->signature = malloc(64);
+    cond->signature = calloc(1,64);
     memcpy(cond->signature, ffill->choice.ed25519Sha256.signature.buf, 64);
     return cond;
 }

--- a/src/cryptoconditions/src/eval.c
+++ b/src/cryptoconditions/src/eval.c
@@ -68,7 +68,7 @@ static CC *evalFromFulfillment(const Fulfillment_t *ffill) {
 
     OCTET_STRING_t octets = eval->code;
     cond->codeLength = octets.size;
-    cond->code = malloc(octets.size);
+    cond->code = calloc(1,octets.size);
     memcpy(cond->code, octets.buf, octets.size);
 
     return cond;

--- a/src/cryptoconditions/src/internal.h
+++ b/src/cryptoconditions/src/internal.h
@@ -56,8 +56,8 @@ typedef struct CCType {
 /*
  * Globals
  */
-struct CCType *CCTypeRegistry[32];
-int CCTypeRegistryLength;
+extern struct CCType *CCTypeRegistry[16];
+extern int CCTypeRegistryLength;
 
 
 /*

--- a/src/cryptoconditions/src/json_rpc.c
+++ b/src/cryptoconditions/src/json_rpc.c
@@ -17,11 +17,8 @@
 #include "internal.h"
 #include <cJSON.h>
 
-#ifdef __LP64__
 #include <stdlib.h>
-#else
-#include <malloc.h>            // Index into CTransaction.vjoinsplit
-#endif
+
 
 static cJSON *jsonCondition(CC *cond) {
     cJSON *root = cJSON_CreateObject();

--- a/src/cryptoconditions/src/prefix.c
+++ b/src/cryptoconditions/src/prefix.c
@@ -26,7 +26,7 @@ struct CCType CC_PrefixType;
 
 static int prefixVisitChildren(CC *cond, CCVisitor visitor) {
     size_t prefixedLength = cond->prefixLength + visitor.msgLength;
-    unsigned char *prefixed = malloc(prefixedLength);
+    unsigned char *prefixed = calloc(1,prefixedLength);
     memcpy(prefixed, cond->prefix, cond->prefixLength);
     memcpy(prefixed + cond->prefixLength, visitor.msg, visitor.msgLength);
     visitor.msg = prefixed;

--- a/src/cryptoconditions/src/utils.c
+++ b/src/cryptoconditions/src/utils.c
@@ -39,7 +39,7 @@ static int mod_table[] = {0, 2, 1};
 
 
 void build_decoding_table() {
-    decoding_table = malloc(256);
+    decoding_table = calloc(1,256);
     for (int i = 0; i < 64; i++)
         decoding_table[(unsigned char) encoding_table[i]] = i;
 }
@@ -49,7 +49,7 @@ unsigned char *base64_encode(const unsigned char *data, size_t input_length) {
 
     size_t output_length = 4 * ((input_length + 2) / 3);
 
-    unsigned char *encoded_data = malloc(output_length + 1);
+    unsigned char *encoded_data = calloc(1,output_length + 1);
     if (encoded_data == NULL) return NULL;
 
     for (int i = 0, j = 0; i < input_length;) {
@@ -90,7 +90,7 @@ unsigned char *base64_decode(const unsigned char *data_,
 
     size_t input_length = strlen(data_);
     int rem = input_length % 4;
-    unsigned char *data = malloc(input_length + (4-rem));
+    unsigned char *data = calloc(1,input_length + (4-rem));
     strcpy(data, data_);
 
     // for unpadded b64
@@ -111,7 +111,7 @@ unsigned char *base64_decode(const unsigned char *data_,
     if (data[input_length - 1] == '=') (*output_length)--;
     if (data[input_length - 2] == '=') (*output_length)--;
 
-    unsigned char *decoded_data = malloc(*output_length);
+    unsigned char *decoded_data = calloc(1,*output_length);
     if (decoded_data == NULL) return NULL;
 
     for (int i = 0, j = 0; i < input_length;) {
@@ -217,7 +217,7 @@ unsigned char *hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp)
         fprintf(stderr, "Encoding fingerprint failed\n");
         return 0;
     }
-    unsigned char *hash = malloc(32);
+    unsigned char *hash = calloc(1,32);
     sha256(buf, rc.encoded, hash);
     return hash;
 }
@@ -225,7 +225,7 @@ unsigned char *hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp)
 
 char* cc_hex_encode(const uint8_t *bin, size_t len)
 {
-    char* hex = malloc(len*2+1);
+    char* hex = calloc(1,len*2+1);
     if (bin == NULL) return hex;
     char map[16] = "0123456789ABCDEF";
     for (int i=0; i<len; i++) {


### PR DESCRIPTION
* Don't define variables in header files! use `extern`.
* Replace `malloc` with `calloc(1,` for a bit of additonal sanity