### PR TITLE
Removing extra slashes that breaks urls

### DIFF
--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -1,6 +1,6 @@
 package=googletest
 $(package)_version=1.8.0
-$(package)_download_path=https://github.com/google/$(package)/archive/
+$(package)_download_path=https://github.com/google/$(package)/archive
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_download_file=release-$($(package)_version).tar.gz
 $(package)_sha256_hash=58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,6 +1,6 @@
 package=libevent
 $(package)_version=2.1.8
-$(package)_download_path=https://github.com/libevent/libevent/archive/
+$(package)_download_path=https://github.com/libevent/libevent/archive
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_download_file=release-$($(package)_version)-stable.tar.gz
 $(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d

--- a/depends/packages/libgmp.mk
+++ b/depends/packages/libgmp.mk
@@ -1,7 +1,7 @@
 package=libgmp
 
 ifeq ($(host_os),mingw32)
-$(package)_download_path=https://github.com/joshuayabut/$(package)/archive/
+$(package)_download_path=https://github.com/joshuayabut/$(package)/archive
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
 $(package)_sha256_hash=193836c1acc9dc00fe2521205d7bbe1ba13263f6cbef6f02584bf6f8b34b108f
@@ -9,7 +9,7 @@ $(package)_git_commit=053c03b1cab347671d936f43ef66b48ab5e380ee
 $(package)_dependencies=
 $(package)_config_opts=--enable-cxx --disable-shared
 else ifeq ($(build_os),darwin)
-$(package)_download_path=https://github.com/ca333/$(package)/archive/
+$(package)_download_path=https://github.com/ca333/$(package)/archive
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
 $(package)_sha256_hash=59b2c2b5d58fdf5943bfde1fa709e9eb53e7e072c9699d28dc1c2cbb3c8cc32c

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -1,6 +1,6 @@
 package=librustzcash
 $(package)_version=0.1
-$(package)_download_path=https://github.com/zcash/$(package)/archive/
+$(package)_download_path=https://github.com/zcash/$(package)/archive
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
 $(package)_sha256_hash=a5760a90d4a1045c8944204f29fa2a3cf2f800afee400f88bf89bbfe2cce1279

--- a/depends/packages/libsodium.mk
+++ b/depends/packages/libsodium.mk
@@ -9,7 +9,7 @@ $(package)_config_opts=
 else
 package=libsodium
 $(package)_version=1.0.15
-$(package)_download_path=https://download.libsodium.org/libsodium/releases/
+$(package)_download_path=https://download.libsodium.org/libsodium/releases
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
 $(package)_dependencies=

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,6 +1,6 @@
 ifeq ($(host_os),mingw32)
 $(package)_version=4.2.2-1
-$(package)_download_path=https://github.com/ca333/libzmq/archive/
+$(package)_download_path=https://github.com/ca333/libzmq/archive
 $(package)_download_file=v$($(package)_version).tar.gz
 $(package)_file_name=libzmq-$($(package)_version).tar.gz
 $(package)_sha256_hash=0e225b85ce11be23bf7eb7d3f25c6686728bf30d5c31f61c12d37bb646c69962
@@ -15,7 +15,7 @@ endef
 else
 package=zeromq
 $(package)_version=4.2.1
-$(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
+$(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=27d1e82a099228ee85a7ddb2260f40830212402c605a4a10b5e5498a7e0e9d03
 

--- a/libsnark.mk.patch
+++ b/libsnark.mk.patch
@@ -4,7 +4,7 @@
 *** 1,30 ****
   package=libsnark
   $(package)_version=0.1
-! $(package)_download_path=https://github.com/radix42/$(package)/archive/
+! $(package)_download_path=https://github.com/radix42/$(package)/archive
   $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
   $(package)_download_file=$($(package)_git_commit).tar.gz
 ! $(package)_sha256_hash=9dbd5b44d3443e86463e934bfe1023cab4ca5948f8d74c23a67d9535c28d2584
@@ -35,7 +35,7 @@
 --- 1,17 ----
   package=libsnark
   $(package)_version=0.1
-! $(package)_download_path=https://github.com/zcash/$(package)/archive/
+! $(package)_download_path=https://github.com/zcash/$(package)/archive
   $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
   $(package)_download_file=$($(package)_git_commit).tar.gz
 ! $(package)_sha256_hash=9422b1a2a94e6b8be61f07af7f146087c2a7d70b208d07ad076622225aa7f0e4


### PR DESCRIPTION
The slashes resulted in double slashes where there shouldn't be.
e.g:
https://github.com/ca333/libzmq/archive//v4.2.2-1.tar.gz
