### PR TITLE
cctests sync

### DIFF
--- a/qa/rpc-tests/cryptoconditions.py
+++ b/qa/rpc-tests/cryptoconditions.py
@@ -68,7 +68,7 @@ class CryptoConditionsTest (BitcoinTestFramework):
 
         # basic sanity tests
         result = rpc.getwalletinfo()
-        assert_equal(result['txcount'], 101)
+        assert_greater_than(result['txcount'], 100)
         assert_greater_than(result['balance'], 0.0)
         balance = result['balance']
 

--- a/qa/rpc-tests/cryptoconditions.py
+++ b/qa/rpc-tests/cryptoconditions.py
@@ -43,7 +43,7 @@ class CryptoConditionsTest (BitcoinTestFramework):
                     '-ac_supply=5555555',
                     '-ac_reward=10000000',
                     '-pubkey=' + self.pubkey,
-                    '-ac_cc=1',
+                    '-ac_cc=2',
                     '-whitelist=127.0.0.1',
                     '-debug',
                     '-daemon',

--- a/qa/rpc-tests/cryptoconditions.py
+++ b/qa/rpc-tests/cryptoconditions.py
@@ -6,7 +6,7 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_greater_than, \
-    initialize_chain_clean, start_nodes, start_node, connect_nodes_bi, \
+    initialize_chain_clean, initialize_chain, start_nodes, start_node, connect_nodes_bi, \
     stop_nodes, sync_blocks, sync_mempools, wait_bitcoinds, rpc_port
 
 import time
@@ -327,10 +327,10 @@ class CryptoConditionsTest (BitcoinTestFramework):
         print("Importing privkey")
         rpc.importprivkey(self.privkey)
 
-        self.run_faucet_tests()
         self.run_rewards_tests()
         self.run_dice_tests()
         self.run_token_tests()
+        self.run_faucet_tests()
 
 
 if __name__ == '__main__':

--- a/src/cc/dice.cpp
+++ b/src/cc/dice.cpp
@@ -15,6 +15,8 @@
 
 #include "CCdice.h"
 
+extern std::string CCerror;
+
 // timeout
 
 /*
@@ -949,7 +951,8 @@ std::string DiceBetFinish(int32_t *resultp,uint64_t txfee,char *planstr,uint256 
     //char str[65]; fprintf(stderr,"DiceBetFinish.%s %s\n",planstr,uint256_str(str,bettxid));
     if ( (cp= Diceinit(fundingPubKey,fundingtxid,&C,planstr,txfee,mypk,dicepk,sbits,minbet,maxbet,maxodds,timeoutblocks)) == 0 )
     {
-        fprintf(stderr,"Diceinit error\n");
+        CCerror = "Diceinit error";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     fundingpk = DiceFundingPk(fundingPubKey);
@@ -964,7 +967,8 @@ std::string DiceBetFinish(int32_t *resultp,uint64_t txfee,char *planstr,uint256 
     }
     if ( AddNormalinputs(mtx,mypk,txfee,1) == 0 )
     {
-        fprintf(stderr,"no txfee inputs for win/lose\n");
+        CCerror = "no txfee inputs for win/lose";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     if ( GetTransaction(bettxid,betTx,hashBlock,false) != 0 && GetTransaction(betTx.vin[0].prevout.hash,entropyTx,hashBlock,false) != 0 )
@@ -978,7 +982,8 @@ std::string DiceBetFinish(int32_t *resultp,uint64_t txfee,char *planstr,uint256 
             {
                 if ( myIsutxo_spentinmempool(bettxid,0) != 0 || myIsutxo_spentinmempool(bettxid,1) != 0 )
                 {
-                    fprintf(stderr,"bettxid already spent\n");
+                    CCerror = "bettxid already spent";
+                    fprintf(stderr,"%s\n", CCerror.c_str() );
                     return("");
                 }
                 //fprintf(stderr,"iswin.%d matches\n",iswin);
@@ -1056,7 +1061,8 @@ double DiceStatus(uint64_t txfee,char *planstr,uint256 fundingtxid,uint256 bettx
     CScript fundingPubKey,scriptPubKey; CTransaction spenttx,betTx; uint256 hash,proof,txid,hashBlock,spenttxid; CPubKey mypk,dicepk,fundingpk; struct CCcontract_info *cp,C; int32_t i,result,vout,n=0; int64_t minbet,maxbet,maxodds,timeoutblocks; uint64_t sbits; char coinaddr[64]; std::string res;
     if ( (cp= Diceinit(fundingPubKey,fundingtxid,&C,planstr,txfee,mypk,dicepk,sbits,minbet,maxbet,maxodds,timeoutblocks)) == 0 )
     {
-        fprintf(stderr,"Diceinit error\n");
+        CCerror = "Diceinit error";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return(0.);
     }
     fundingpk = DiceFundingPk(fundingPubKey);

--- a/src/cc/dice.cpp
+++ b/src/cc/dice.cpp
@@ -859,12 +859,17 @@ std::string DiceCreateFunding(uint64_t txfee,char *planstr,int64_t funds,int64_t
     CMutableTransaction mtx; uint256 zero; CScript fundingPubKey; CPubKey mypk,dicepk; int64_t a,b,c,d; uint64_t sbits; struct CCcontract_info *cp,C;
     if ( funds < 0 || minbet < 0 || maxbet < 0 || maxodds < 1 || maxodds > 9999 || timeoutblocks < 0 || timeoutblocks > 1440 )
     {
-        fprintf(stderr,"negative parameter error\n");
+        CCerror = "invalid parameter error";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     memset(&zero,0,sizeof(zero));
     if ( (cp= Diceinit(fundingPubKey,zero,&C,planstr,txfee,mypk,dicepk,sbits,a,b,c,d)) == 0 )
+    {
+        CCerror = "Diceinit error";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
+    }
     if ( AddNormalinputs(mtx,mypk,funds+3*txfee,60) > 0 )
     {
         mtx.vout.push_back(MakeCC1vout(cp->evalcode,funds,dicepk));
@@ -872,7 +877,8 @@ std::string DiceCreateFunding(uint64_t txfee,char *planstr,int64_t funds,int64_t
         mtx.vout.push_back(CTxOut(txfee,CScript() << ParseHex(HexStr(dicepk)) << OP_CHECKSIG));
         return(FinalizeCCTx(0,cp,mtx,mypk,txfee,EncodeDiceFundingOpRet('F',sbits,minbet,maxbet,maxodds,timeoutblocks)));
     }
-    fprintf(stderr,"cant find enough inputs\n");
+    CCerror = "cant find enough inputs";
+    fprintf(stderr,"%s\n", CCerror.c_str() );
     return("");
 }
 
@@ -881,7 +887,8 @@ std::string DiceAddfunding(uint64_t txfee,char *planstr,uint256 fundingtxid,int6
     CMutableTransaction mtx; CScript fundingPubKey,scriptPubKey; uint256 entropy,hentropy; CPubKey mypk,dicepk; uint64_t sbits; struct CCcontract_info *cp,C; int64_t minbet,maxbet,maxodds,timeoutblocks;
     if ( amount < 0 )
     {
-        fprintf(stderr,"negative parameter\n");
+        CCerror = "amount must be positive";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     if ( (cp= Diceinit(fundingPubKey,fundingtxid,&C,planstr,txfee,mypk,dicepk,sbits,minbet,maxbet,maxodds,timeoutblocks)) == 0 )
@@ -907,31 +914,46 @@ std::string DiceAddfunding(uint64_t txfee,char *planstr,uint256 fundingtxid,int6
             mtx.vout.push_back(MakeCC1vout(cp->evalcode,amount,dicepk));
             mtx.vout.push_back(CTxOut(txfee,fundingPubKey));
             return(FinalizeCCTx(0,cp,mtx,mypk,txfee,EncodeDiceOpRet('E',sbits,fundingtxid,hentropy,zeroid)));
-        } else fprintf(stderr,"cant find enough inputs\n");
-    } else fprintf(stderr,"only fund creator can add more funds (entropy)\n");
+        } else {
+            CCerror = "cant find enough inputs";
+            fprintf(stderr,"%s\n", CCerror.c_str() );
+        }
+    } else {
+        CCerror = "only fund creator can add more funds (entropy)";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
+    }
     return("");
 }
 
 std::string DiceBet(uint64_t txfee,char *planstr,uint256 fundingtxid,int64_t bet,int32_t odds)
 {
     CMutableTransaction mtx; CScript fundingPubKey; CPubKey mypk,dicepk; uint64_t sbits,entropyval; int64_t funding,minbet,maxbet,maxodds,timeoutblocks; uint256 entropytxid,entropy,hentropy; struct CCcontract_info *cp,C;
-    if ( bet < 0 || odds < 1 || odds > 9999 )
+    if ( bet < 0 )
     {
-        fprintf(stderr,"negative parameter or odds too big error\n");
+        CCerror = "bet must be positive";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
+        return("");
+    }
+    if ( odds < 1 || odds > 9999 )
+    {
+        CCerror = "odds must be between 1 and 9999";
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     if ( (cp= Diceinit(fundingPubKey,fundingtxid,&C,planstr,txfee,mypk,dicepk,sbits,minbet,maxbet,maxodds,timeoutblocks)) == 0 )
         return("");
     if ( bet < minbet || bet > maxbet || odds > maxodds )
     {
-        fprintf(stderr,"Dice plan %s illegal bet %.8f: minbet %.8f maxbet %.8f or odds %d vs max.%d\n",planstr,(double)bet/COIN,(double)minbet/COIN,(double)maxbet/COIN,(int32_t)odds,(int32_t)maxodds);
+        CCerror = strprintf("Dice plan %s illegal bet %.8f: minbet %.8f maxbet %.8f or odds %d vs max.%d\n",planstr,(double)bet/COIN,(double)minbet/COIN,(double)maxbet/COIN,(int32_t)odds,(int32_t)maxodds);
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     if ( (funding= DicePlanFunds(entropyval,entropytxid,sbits,cp,dicepk,fundingtxid)) >= 2*bet*odds+txfee && entropyval != 0 )
     {
         if ( myIsutxo_spentinmempool(entropytxid,0) != 0 )
         {
-            fprintf(stderr,"entropy txid is spent\n");
+            CCerror = "entropy txid is spent";
+            fprintf(stderr,"%s\n", CCerror.c_str() );
             return("");
         }
         mtx.vin.push_back(CTxIn(entropytxid,0,CScript()));
@@ -945,8 +967,10 @@ std::string DiceBet(uint64_t txfee,char *planstr,uint256 fundingtxid,int64_t bet
         } else fprintf(stderr,"cant find enough inputs %.8f note enough for %.8f\n",(double)funding/COIN,(double)bet/COIN);
     }
     if ( entropyval == 0 && funding != 0 )
-        fprintf(stderr,"cant find dice entropy inputs\n");
-    else fprintf(stderr,"cant find dice inputs\n");
+        CCerror = "cant find dice entropy inputs";
+    else
+        CCerror = "cant find dice input";
+    fprintf(stderr,"%s\n", CCerror.c_str() );
     return("");
 }
 
@@ -1015,7 +1039,8 @@ std::string DiceBetFinish(int32_t *resultp,uint64_t txfee,char *planstr,uint256 
                     odds = (betTx.vout[2].nValue - txfee);
                     if ( odds < 1 || odds > maxodds )
                     {
-                        fprintf(stderr,"illegal odds.%d vs maxodds.%d\n",(int32_t)odds,(int32_t)maxodds);
+                        CCerror = strprintf("illegal odds.%d vs maxodds.%d\n",(int32_t)odds,(int32_t)maxodds);
+                        fprintf(stderr,"%s\n", CCerror.c_str() );
                         return("");
                     }
                     CCchange = betTx.vout[0].nValue + betTx.vout[1].nValue;
@@ -1029,7 +1054,8 @@ std::string DiceBetFinish(int32_t *resultp,uint64_t txfee,char *planstr,uint256 
                     }
                     else
                     {
-                        fprintf(stderr,"not enough inputs for %.8f\n",(double)fundsneeded/COIN);
+                        CCerror = strprintf("not enough inputs for %.8f\n",(double)fundsneeded/COIN);
+                        fprintf(stderr,"%s\n", CCerror.c_str() );
                         return("");
                     }
                     mtx.vout.push_back(MakeCC1vout(cp->evalcode,CCchange,dicepk));
@@ -1058,7 +1084,8 @@ std::string DiceBetFinish(int32_t *resultp,uint64_t txfee,char *planstr,uint256 
         }
     }
     *resultp = -1;
-    fprintf(stderr,"couldnt find bettx or entropytx\n");
+    CCerror = "couldnt find bettx or entropytx";
+    fprintf(stderr,"%s\n", CCerror.c_str() );
     return("");
 }
 

--- a/src/cc/rewards.cpp
+++ b/src/cc/rewards.cpp
@@ -539,7 +539,8 @@ std::string RewardsAddfunding(uint64_t txfee,char *planstr,uint256 fundingtxid,i
     sbits = stringbits(planstr);
     if ( RewardsPlanExists(cp,sbits,rewardspk,a,b,c,d) == 0 )
     {
-        fprintf(stderr,"Rewards plan %s doesnt exist\n",planstr);
+        CCerror = strprintf("Rewards plan %s doesnt exist\n",planstr);
+        fprintf(stderr,"%s\n",CCerror.c_str());
         return("");
     }
     sbits = stringbits(planstr);
@@ -547,8 +548,12 @@ std::string RewardsAddfunding(uint64_t txfee,char *planstr,uint256 fundingtxid,i
     {
         mtx.vout.push_back(MakeCC1vout(cp->evalcode,amount,rewardspk));
         return(FinalizeCCTx(0,cp,mtx,mypk,txfee,EncodeRewardsOpRet('A',sbits,fundingtxid)));
-    } else fprintf(stderr,"cant find enough inputs\n");
-    fprintf(stderr,"cant find fundingtxid\n");
+    } else {
+        CCerror = "cant find enough inputs";
+        fprintf(stderr,"%s\n", CCerror.c_str());
+    }
+    CCerror = "cant find fundingtxid";
+    fprintf(stderr,"%s\n", CCerror.c_str());
     return("");
 }
 
@@ -557,7 +562,8 @@ std::string RewardsLock(uint64_t txfee,char *planstr,uint256 fundingtxid,int64_t
     CMutableTransaction mtx; CPubKey mypk,rewardspk; CScript opret; uint64_t lockedfunds,sbits,funding,APR,minseconds,maxseconds,mindeposit; struct CCcontract_info *cp,C;
     if ( deposit < txfee )
     {
-        fprintf(stderr,"deposit amount less than txfee\n");
+        CCerror = "deposit amount less than txfee";
+        fprintf(stderr,"%s\n",CCerror.c_str());
         return("");
     }
     cp = CCinit(&C,EVAL_REWARDS);
@@ -568,12 +574,14 @@ std::string RewardsLock(uint64_t txfee,char *planstr,uint256 fundingtxid,int64_t
     sbits = stringbits(planstr);
     if ( RewardsPlanExists(cp,sbits,rewardspk,APR,minseconds,maxseconds,mindeposit) == 0 )
     {
-        fprintf(stderr,"Rewards plan %s doesnt exist\n",planstr);
+        CCerror = strprintf("Rewards plan %s doesnt exist\n",planstr);
+        fprintf(stderr,"%s\n",CCerror.c_str());
         return("");
     }
     if ( deposit < mindeposit )
     {
-        fprintf(stderr,"Rewards plan %s deposit %.8f < mindeposit %.8f\n",planstr,(double)deposit/COIN,(double)mindeposit/COIN);
+        CCerror = strprintf("Rewards plan %s deposit %.8f < mindeposit %.8f\n",planstr,(double)deposit/COIN,(double)mindeposit/COIN);
+        fprintf(stderr,"%s\n",CCerror.c_str());
         return("");
     }
     if ( (funding= RewardsPlanFunds(lockedfunds,sbits,cp,rewardspk,fundingtxid)) >= deposit ) // arbitrary cmpval
@@ -583,7 +591,10 @@ std::string RewardsLock(uint64_t txfee,char *planstr,uint256 fundingtxid,int64_t
             mtx.vout.push_back(MakeCC1vout(cp->evalcode,deposit,rewardspk));
             mtx.vout.push_back(CTxOut(txfee,CScript() << ParseHex(HexStr(mypk)) << OP_CHECKSIG));
             return(FinalizeCCTx(0,cp,mtx,mypk,txfee,EncodeRewardsOpRet('L',sbits,fundingtxid)));
-        } else fprintf(stderr,"cant find enough inputs %.8f not enough for %.8f, make sure you imported privkey for the -pubkey address\n",(double)funding/COIN,(double)deposit/COIN);
+        } else {
+            CCerror = strprintf("cant find enough inputs %.8f not enough for %.8f, make sure you imported privkey for the -pubkey address\n",(double)funding/COIN,(double)deposit/COIN);
+            fprintf(stderr,"%s\n",CCerror.c_str());
+        }
     }
     fprintf(stderr,"cant find rewards inputs funding %.8f locked %.8f vs deposit %.8f\n",(double)funding/COIN,(double)lockedfunds/COIN,(double)deposit/COIN);
     return("");

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -203,6 +203,7 @@ bool CheckProofOfWork(int32_t height,uint8_t *pubkey33,uint256 hash,unsigned int
         if ( ASSETCHAINS_SYMBOL[0] != 0 || height > 792000 )
         {
             //if ( 0 && height > 792000 )
+            if ( Params().NetworkIDString() != "regtest" )
             {
                 for (i=31; i>=0; i--)
                     fprintf(stderr,"%02x",((uint8_t *)&hash)[i]);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4968,7 +4968,7 @@ UniValue tokenaddress(const UniValue& params, bool fHelp)
 
 UniValue rewardscreatefunding(const UniValue& params, bool fHelp)
 {
-    UniValue result(UniValue::VOBJ); char *name; uint64_t funds,APR,minseconds,maxseconds,mindeposit; std::string hex;
+    UniValue result(UniValue::VOBJ); char *name; int64_t funds,APR,minseconds,maxseconds,mindeposit; std::string hex;
     if ( fHelp || params.size() > 6 || params.size() < 2 )
         throw runtime_error("rewardscreatefunding name amount APR mindays maxdays mindeposit\n");
     if ( ensure_CCrequirements() < 0 )
@@ -4981,17 +4981,43 @@ UniValue rewardscreatefunding(const UniValue& params, bool fHelp)
     mindeposit = 100 * COIN;
     name = (char *)params[0].get_str().c_str();
     funds = atof(params[1].get_str().c_str()) * COIN;
+
+    if ( funds <= 0 ) {
+        ERR_RESULT("funds must be positive");
+        return result;
+    }
     if ( params.size() > 2 )
     {
         APR = atof(params[2].get_str().c_str()) * COIN;
+        if ( APR > REWARDSCC_MAXAPR )
+        {
+            ERR_RESULT("25% APR is maximum");
+            return result;
+        }
         if ( params.size() > 3 )
         {
             minseconds = atol(params[3].get_str().c_str()) * 3600 * 24;
+            if ( minseconds < 0 ) {
+                ERR_RESULT("mindays must be non-negative");
+                return result;
+            }
             if ( params.size() > 4 )
             {
                 maxseconds = atol(params[4].get_str().c_str()) * 3600 * 24;
+                if ( maxseconds <= 0 ) {
+                    ERR_RESULT("maxdays must be positive");
+                    return result;
+                }
+                if ( maxseconds < minseconds ) {
+                    ERR_RESULT("maxdays must be greater than mindays");
+                    return result;
+                }
                 if ( params.size() > 5 )
                     mindeposit = atof(params[5].get_str().c_str()) * COIN;
+                    if ( mindeposit <= 0 ) {
+                        ERR_RESULT("mindeposit must be positive");
+                        return result;
+                    }
             }
         }
     }
@@ -5017,7 +5043,9 @@ UniValue rewardslock(const UniValue& params, bool fHelp)
     fundingtxid = Parseuint256((char *)params[1].get_str().c_str());
     amount = atof(params[2].get_str().c_str()) * COIN;
     hex = RewardsLock(0,name,fundingtxid,amount);
-    if ( amount > 0 ) {
+    if ( CCerror != "" ){
+        ERR_RESULT(CCerror);
+    } else if ( amount > 0 ) {
         if ( hex.size() > 0 )
         {
             result.push_back(Pair("result", "success"));
@@ -5040,7 +5068,9 @@ UniValue rewardsaddfunding(const UniValue& params, bool fHelp)
     fundingtxid = Parseuint256((char *)params[1].get_str().c_str());
     amount = atof(params[2].get_str().c_str()) * COIN;
     hex = RewardsAddfunding(0,name,fundingtxid,amount);
-    if (amount > 0) {
+    if (CCerror != "") {
+        ERR_RESULT(CCerror);
+    } else if (amount > 0) {
         if ( hex.size() > 0 )
         {
             result.push_back(Pair("result", "success"));
@@ -5050,8 +5080,7 @@ UniValue rewardsaddfunding(const UniValue& params, bool fHelp)
             result.push_back(Pair("error", "couldnt create rewards addfunding transaction"));
         }
     } else {
-            result.push_back(Pair("result", "error"));
-            result.push_back(Pair("error", "funding amount must be positive"));
+            ERR_RESULT("funding amount must be positive");
     }
     return(result);
 }
@@ -5260,7 +5289,7 @@ UniValue dicebet(const UniValue& params, bool fHelp)
         {
             result.push_back(Pair("result", "success"));
             result.push_back(Pair("hex", hex));
-        } else ERR_RESULT("couldnt create faucet get transaction");
+        } else ERR_RESULT("couldnt create dice bet transaction");
     } else {
         ERR_RESULT("amount and odds must be positive");
     }
@@ -5280,7 +5309,10 @@ UniValue dicefinish(const UniValue& params, bool fHelp)
     fundingtxid = Parseuint256((char *)params[1].get_str().c_str());
     bettxid = Parseuint256((char *)params[2].get_str().c_str());
     hex = DiceBetFinish(&r,0,name,fundingtxid,bettxid,1);
-    if ( hex.size() > 0 )
+    if ( CCerror != "" )
+    {
+        ERR_RESULT(CCerror);
+    } else if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
         result.push_back(Pair("hex", hex));
@@ -5303,6 +5335,10 @@ UniValue dicestatus(const UniValue& params, bool fHelp)
     if ( params.size() == 3 )
         bettxid = Parseuint256((char *)params[2].get_str().c_str());
     winnings = DiceStatus(0,name,fundingtxid,bettxid);
+    if (CCerror != "") {
+        ERR_RESULT(CCerror);
+        return result;
+    }
     result.push_back(Pair("result", "success"));
     if ( winnings >= 0. )
     {
@@ -5528,7 +5564,7 @@ UniValue tokencancelbid(const UniValue& params, bool fHelp)
 
 UniValue tokenfillbid(const UniValue& params, bool fHelp)
 {
-    UniValue result(UniValue::VOBJ); uint64_t fillamount; std::string hex; uint256 tokenid,bidtxid;
+    UniValue result(UniValue::VOBJ); int64_t fillamount; std::string hex; uint256 tokenid,bidtxid;
     if ( fHelp || params.size() != 3 )
         throw runtime_error("tokenfillbid tokenid bidtxid fillamount\n");
     if ( ensure_CCrequirements() < 0 )
@@ -5538,9 +5574,14 @@ UniValue tokenfillbid(const UniValue& params, bool fHelp)
     tokenid = Parseuint256((char *)params[0].get_str().c_str());
     bidtxid = Parseuint256((char *)params[1].get_str().c_str());
     fillamount = atol(params[2].get_str().c_str());
-    if ( tokenid == zeroid || bidtxid == zeroid || fillamount <= 0 )
+    if ( fillamount <= 0 )
     {
-        result.push_back(Pair("error", "invalid parameter"));
+        ERR_RESULT("fillamount must be positive");
+        return(result);
+    }
+    if ( tokenid == zeroid || bidtxid == zeroid )
+    {
+        ERR_RESULT("must provide tokenid and bidtxid");
         return(result);
     }
     hex = FillBuyOffer(0,tokenid,bidtxid,fillamount);
@@ -5567,7 +5608,7 @@ UniValue tokenask(const UniValue& params, bool fHelp)
     askamount = (price * numtokens) * COIN + 0.0000000049999;
     if ( tokenid == zeroid || numtokens <= 0 || price <= 0 || askamount <= 0 )
     {
-        result.push_back(Pair("error", "invalid parameter"));
+        ERR_RESULT("invalid parameter");
         return(result);
     }
     hex = CreateSell(0,numtokens,tokenid,askamount);
@@ -5638,7 +5679,7 @@ UniValue tokencancelask(const UniValue& params, bool fHelp)
 
 UniValue tokenfillask(const UniValue& params, bool fHelp)
 {
-    UniValue result(UniValue::VOBJ); uint64_t fillunits; std::string hex; uint256 tokenid,asktxid;
+    UniValue result(UniValue::VOBJ); int64_t fillunits; std::string hex; uint256 tokenid,asktxid;
     if ( fHelp || params.size() != 3 )
         throw runtime_error("tokenfillask tokenid asktxid fillunits\n");
     if ( ensure_CCrequirements() < 0 )
@@ -5648,7 +5689,12 @@ UniValue tokenfillask(const UniValue& params, bool fHelp)
     tokenid = Parseuint256((char *)params[0].get_str().c_str());
     asktxid = Parseuint256((char *)params[1].get_str().c_str());
     fillunits = atol(params[2].get_str().c_str());
-    if ( tokenid == zeroid || asktxid == zeroid || fillunits <= 0 )
+    if ( fillunits <= 0 )
+    {
+        ERR_RESULT("fillunits must be positive");
+        return(result);
+    }
+    if ( tokenid == zeroid || asktxid == zeroid )
     {
         result.push_back(Pair("error", "invalid parameter"));
         return(result);


### PR DESCRIPTION
* Enable cc=2 in our regtest chain
* Fix one uint64_t bug
* Improve and add some new error messages to make JSON responses more useful. All prints to stderr have been kept so the current workflow of testers isn't changed
* Run faucet tests last
* Avoid prints about mismatched hashes in regtest
* Fix wrong error message from dicebet

We still have a failing test due to faucets requiring an empty address to receive funds.