### PR TITLE
RPC methods to scan notarisations DB

### DIFF
--- a/src/notarisationdb.h
+++ b/src/notarisationdb.h
@@ -23,5 +23,6 @@ bool GetBlockNotarisations(uint256 blockHash, NotarisationsInBlock &nibs);
 bool GetBackNotarisation(uint256 notarisationHash, Notarisation &n);
 void WriteBackNotarisations(const NotarisationsInBlock notarisations, CLevelDBBatch &batch);
 void EraseBackNotarisations(const NotarisationsInBlock notarisations, CLevelDBBatch &batch);
+int ScanNotarisationsDB(int height, std::string symbol, int scanLimitBlocks, Notarisation& out);
 
 #endif  /* NOTARISATIONDB_H */

--- a/src/rpccrosschain.cpp
+++ b/src/rpccrosschain.cpp
@@ -3,6 +3,7 @@
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "crosschain.h"
+#include "notarisationdb.h"
 #include "importcoin.h"
 #include "base58.h"
 #include "consensus/validation.h"
@@ -250,4 +251,56 @@ UniValue migrate_completeimporttransaction(const UniValue& params, bool fHelp)
     CompleteImportTransaction(importTx);
 
     return HexStr(E_MARSHAL(ss << importTx));
+}
+
+
+UniValue getNotarisationsForBlock(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error("getNotarisationsForBlock blockHash\n\n"
+                "Takes a block hash and returns notarisation transactions "
+                "within the block");
+
+    uint256 blockHash = uint256S(params[0].get_str());
+
+    NotarisationsInBlock nibs;
+    GetBlockNotarisations(blockHash, nibs);
+    UniValue out(UniValue::VARR);
+    BOOST_FOREACH(const Notarisation& n, nibs)
+    {
+        UniValue item(UniValue::VARR);
+        item.push_back(n.first.GetHex());
+        item.push_back(HexStr(E_MARSHAL(ss << n.second)));
+        out.push_back(item);
+    }
+    return out;
+}
+
+
+UniValue scanNotarisationsDB(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() < 2 || params.size() > 3)
+        throw runtime_error("scanNotarisationsDB blockHeight symbol [blocksLimit=1440]\n\n"
+                "Scans notarisationsdb backwards from height for a notarisation"
+                " of given symbol");
+    int height = atoi(params[0].get_str().c_str());
+    std::string symbol = params[1].get_str().c_str();
+
+    int limit = 1440;
+    if (params.size() > 2) {
+        limit = atoi(params[2].get_str().c_str());
+    }
+
+    if (height == 0) {
+        height = chainActive.Height();
+    }
+    
+    Notarisation nota;
+    int matchedHeight = ScanNotarisationsDB(height, symbol, limit, nota);
+    if (!matchedHeight) return NullUniValue;
+    UniValue out(UniValue::VOBJ);
+    out.pushKV("height", matchedHeight);
+    out.pushKV("hash", nota.first.GetHex());
+    out.pushKV("opreturn", HexStr(E_MARSHAL(ss << nota.second)));
+    return out;
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -313,6 +313,8 @@ static const CRPCCommand vRPCCommands[] =
     { "crosschain",         "height_MoM",             &height_MoM,             true  },
     { "crosschain",         "assetchainproof",        &assetchainproof,        true  },
     { "crosschain",         "crosschainproof",        &crosschainproof,        true  },
+    { "crosschain",         "getNotarisationsForBlock", &getNotarisationsForBlock, true },
+    { "crosschain",         "scanNotarisationsDB",    &scanNotarisationsDB,    true },
     { "crosschain",         "migrate_converttoexport", &migrate_converttoexport, true  },
     { "crosschain",         "migrate_createimporttransaction", &migrate_createimporttransaction, true  },
     { "crosschain",         "migrate_completeimporttransaction", &migrate_completeimporttransaction, true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -361,6 +361,8 @@ extern UniValue calc_MoM(const UniValue& params, bool fHelp);
 extern UniValue height_MoM(const UniValue& params, bool fHelp);
 extern UniValue assetchainproof(const UniValue& params, bool fHelp);
 extern UniValue crosschainproof(const UniValue& params, bool fHelp);
+extern UniValue getNotarisationsForBlock(const UniValue& params, bool fHelp);
+extern UniValue scanNotarisationsDB(const UniValue& params, bool fHelp);
 extern UniValue migrate_converttoexport(const UniValue& params, bool fHelp);
 extern UniValue migrate_createimporttransaction(const UniValue& params, bool fHelp);
 extern UniValue migrate_completeimporttransaction(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Add new RPC methods for accessing the notarisations DB in KMD:
`scanNotarisationsDB blockHeight symbol [blocksLimit=1440]`
`getNotarisationsForBlock blockHash`

The first one is most useful, now you can find a notarisation opreturn, for example:
```
$ src/komodo-cli scanNotarisationsDB 981464 BOTS
{
  "height": 981464,
  "hash": "57d333cc73fe5c144053c95bd84b35925d2af6c6cee637a45903dc5b702a1dde",
  "opreturn": "2fac299362e4e2cf0426fc96b17499971ddf4eeb50f9322cd8317c319b85050048410400424f5453008092c029843dea1799cbef5791da13a30ac8a9a40470f75a5b8c342429f79911080000000000000000000000000000000000000000000000000000000000000000000000"
}
$ komodo-cli scanNotarisationsDB 981463 BOTS
{
  "height": 981455,
  "hash": "3b7900dc61cfcc8a5b35941a1ccfdb57edb12e54d3dcdc9c4191f5c182b949fe",
  "opreturn": "98a38e91cfdf6c16ca4e89b141343909e582326dc1d08b2e877022ed9940040040410400424f545300df5eda2705615edd8a639a363ea86bd9f4a0deded6e66c55b6529c3162769a57100000000000000000000000000000000000000000000000000000000000000000000000"
}
```

This can allow making a binary search on the notarisations DB, which can enable making proofs from the outside.