### PR TITLE
Pirate and ac_private tweak

### DIFF
--- a/src/fiat/pirate
+++ b/src/fiat/pirate
@@ -1,0 +1,2 @@
+#!/bin/bash
+./komodo-cli -ac_name=PIRATE $@

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3771,6 +3771,9 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
                 throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, unknown key: ")+s);
         }
 
+        UniValue av = find_value(o, "amount");
+        CAmount nAmount = AmountFromValue( av );
+
         string address = find_value(o, "address").get_str();
         bool isZaddr = false;
         CBitcoinAddress taddr(address);
@@ -3785,7 +3788,10 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             }
         }
         else if ( ASSETCHAINS_PRIVATE != 0 )
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "cant use transparent addresses in private chain");
+        {
+            if (nAmount > 0)
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "cant use transparent addresses with non-zero amounts in private chain");
+        }
 
         if (setAddress.count(address))
             throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+address);
@@ -3805,8 +3811,6 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             }
         }
 
-        UniValue av = find_value(o, "amount");
-        CAmount nAmount = AmountFromValue( av );
         if (nAmount < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, amount must be positive");
 


### PR DESCRIPTION
* Allows creating amount=0 transparent outputs on ac_private chains, in the hopes that it will allow notarization.
* Add PIRATE fiat script

I used this branch to create this transaction:

http://pirate.explorer.dexstats.info/tx/38bcdb30af936861731c1ba02b836849cfaac93f389329751ccd33465d3d04e6

which has an amount=0 transparent output to RYGjg3cbH7EZdquDCKJoDm6fxkMX1SMvGo from a zaddr
