### PR TITLE
Oracles creation RPC checks and tests

### DIFF
--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -859,6 +859,13 @@ UniValue OracleInfo(uint256 origtxid)
     CMutableTransaction mtx; CTransaction regtx,tx; std::string name,description,format; uint256 hashBlock,txid,oracletxid,batontxid; CPubKey pk; struct CCcontract_info *cp,C; int64_t datafee,funding; char str[67],markeraddr[64],numstr[64],batonaddr[64]; std::vector <uint8_t> data;
     cp = CCinit(&C,EVAL_ORACLES);
     CCtxidaddr(markeraddr,origtxid);
+    if ( GetTransaction(origtxid,tx,hashBlock,false) == 0 )
+    {
+        fprintf(stderr,"cant find oracleid\n");
+        result.push_back(Pair("result","error"));
+        result.push_back(Pair("error","cant find oracleid"));
+        return(result);
+    }
     if ( GetTransaction(origtxid,tx,hashBlock,false) != 0 )
     {
         if ( tx.vout.size() > 0 && DecodeOraclesCreateOpRet(tx.vout[tx.vout.size()-1].scriptPubKey,name,description,format) == 'C' )

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5733,6 +5733,24 @@ UniValue oraclescreate(const UniValue& params, bool fHelp)
         ERR_RESULT("oracles format must be <= 4096 characters");
         return(result);
     }
+    // list of oracle valid formats from oracles.cpp -> oracle_format
+    const UniValue valid_formats[13] = {"s","S","d","D","c","C","t","T","i","I","l","L","h"};
+    const UniValue header_type = "Ihh";
+    // checking if oracle data type is valid
+    bool is_valid_format = false;
+    for ( int i = 0; i < 13; ++i ) {
+        if ( valid_formats[i].get_str() == format ) {
+            is_valid_format = true;
+        }
+    }
+    // additional check for special Ihh data type
+    if ( format == header_type.get_str() ) {
+        is_valid_format = true;
+    }
+    if ( !is_valid_format ) {
+        ERR_RESULT("oracles format not valid");
+        return(result);
+    }
     hex = OracleCreate(0,name,description,format);
     if ( hex.size() > 0 )
     {


### PR DESCRIPTION
- Added validation for oraclesinfo in case of non existing oracleid input
- Added oracle data type validation on call (list is hardcoded in rpcwallet)
- Made oracle creation stage rpc tests