### PR TITLE
Get dice CC compiling again

### DIFF
--- a/src/cc/dice.cpp
+++ b/src/cc/dice.cpp
@@ -1579,9 +1579,9 @@ std::string DiceBetFinish(uint8_t &funcid,uint256 &entropyused,int32_t &entropyv
                     }
                     CCchange = betTx.vout[0].nValue + betTx.vout[1].nValue;
                     fundsneeded = txfee + (odds+1)*betTx.vout[1].nValue;
+                    savemtx = mtx;
                     if ( CCchange >= fundsneeded )
                         CCchange -= fundsneeded;
-                    savemtx = mtx;
                     else if ( (inputs= AddDiceInputs(cp,mtx,dicepk,fundsneeded,1,sbits,fundingtxid)) >= fundsneeded )
                     {
                         if ( inputs > fundsneeded )


### PR DESCRIPTION
This gets things going further, but still running into this:

```
libbitcoin_server.a(libbitcoin_server_a-main.o): In function `LoadBlockIndexDB()':
/home/dukeleto/git/komodo/src/main.cpp:5547: undefined reference to `EnforceNodeDeprecation(int, bool)'
libbitcoin_server.a(libbitcoin_server_a-main.o): In function `ConnectTip':
/home/dukeleto/git/komodo/src/main.cpp:3897: undefined reference to `EnforceNodeDeprecation(int, bool)'
collect2: error: ld returned 1 exit status
Makefile:2193: recipe for target 'komodo-test' failed
make[2]: *** [komodo-test] Error 1
make[2]: *** Waiting for unfinished jobs....
libbitcoin_server.a(libbitcoin_server_a-main.o): In function `LoadBlockIndexDB()':
/home/dukeleto/git/komodo/src/main.cpp:5547: undefined reference to `EnforceNodeDeprecation(int, bool)'
libbitcoin_server.a(libbitcoin_server_a-main.o): In function `ConnectTip':
/home/dukeleto/git/komodo/src/main.cpp:3897: undefined reference to `EnforceNodeDeprecation(int, bool)'
collect2: error: ld returned 1 exit status
```