### PR TITLE
Add various error checking to gateway + oracle RPCs

### DIFF
--- a/src/cc/gateways.cpp
+++ b/src/cc/gateways.cpp
@@ -576,7 +576,8 @@ std::string GatewaysBind(uint64_t txfee,std::string coin,uint256 tokenid,int64_t
         mtx.vout.push_back(MakeCC1vout(cp->evalcode,txfee,gatewayspk));
         return(FinalizeCCTx(0,cp,mtx,mypk,txfee,EncodeGatewaysBindOpRet('B',coin,tokenid,totalsupply,oracletxid,M,N,pubkeys,taddr,prefix,prefix2)));
     }
-    fprintf(stderr,"cant find enough inputs\n");
+    CCerror = strprintf("cant find enough inputs");
+    fprintf(stderr,"%s\n", CCerror.c_str() );
     return("");
 }
 
@@ -797,7 +798,8 @@ std::string GatewaysClaim(uint64_t txfee,uint256 bindtxid,std::string refcoin,ui
             return(FinalizeCCTx(0,cp,mtx,mypk,txfee,EncodeAssetOpRet('t',assetid,zeroid,0,Mypubkey())));
         }
     }
-    fprintf(stderr,"cant find enough inputs or mismatched total\n");
+    CCerror = strprintf("cant find enough inputs or mismatched total");
+    fprintf(stderr,"%s\n", CCerror.c_str() );
     return("");
 }
 
@@ -836,7 +838,8 @@ std::string GatewaysWithdraw(uint64_t txfee,uint256 bindtxid,std::string refcoin
             return(FinalizeCCTx(0,cp,mtx,mypk,txfee,opret));
         }
     }
-    fprintf(stderr,"cant find enough inputs or mismatched total\n");
+    CCerror = strprintf("cant find enough inputs or mismatched total");
+    fprintf(stderr,"%s\n", CCerror.c_str() );
     return("");
 }
 

--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -794,13 +794,13 @@ std::string OracleData(int64_t txfee,uint256 oracletxid,std::vector <uint8_t> da
     mypk = pubkey2pk(Mypubkey());
     if ( data.size() > 8192 )
     {
-        CCerror = strprintf("datasize %d is too big\n",(int32_t)data.size());
+        CCerror = strprintf("datasize %d is too big",(int32_t)data.size());
         fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     if ( (datafee= OracleDatafee(pubKey,oracletxid,mypk)) <= 0 )
     {
-        CCerror = strprintf("datafee %.8f is illegal\n",(double)datafee/COIN);
+        CCerror = strprintf("datafee %.8f is illegal",(double)datafee/COIN);
         fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
@@ -822,8 +822,14 @@ std::string OracleData(int64_t txfee,uint256 oracletxid,std::vector <uint8_t> da
             mtx.vout.push_back(MakeCC1vout(cp->evalcode,txfee,batonpk));
             mtx.vout.push_back(CTxOut(datafee,CScript() << ParseHex(HexStr(mypk)) << OP_CHECKSIG));
             return(FinalizeCCTx(0,cp,mtx,mypk,txfee,EncodeOraclesData('D',oracletxid,batontxid,mypk,data)));
-        } else fprintf(stderr,"couldnt find enough oracle inputs %s, limit 1 per utxo\n",coinaddr);
-    } else fprintf(stderr,"couldnt add normal inputs\n");
+        } else {
+            CCerror = strprintf("couldnt find enough oracle inputs %s, limit 1 per utxo\n",coinaddr);
+            fprintf(stderr,"%s\n", CCerror.c_str() );
+        }
+    } else {
+        CCerror = strprintf("couldnt add normal inputs\n");
+        fprintf(stderr,"%s\n", CCerror.c_str() );
+    }
     return("");
 }
 

--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -794,12 +794,14 @@ std::string OracleData(int64_t txfee,uint256 oracletxid,std::vector <uint8_t> da
     mypk = pubkey2pk(Mypubkey());
     if ( data.size() > 8192 )
     {
-        fprintf(stderr,"datasize %d is too big\n",(int32_t)data.size());
+        CCerror = strprintf("datasize %d is too big\n",(int32_t)data.size());
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     if ( (datafee= OracleDatafee(pubKey,oracletxid,mypk)) <= 0 )
     {
-        fprintf(stderr,"datafee %.8f is illegal\n",(double)datafee/COIN);
+        CCerror = strprintf("datafee %.8f is illegal\n",(double)datafee/COIN);
+        fprintf(stderr,"%s\n", CCerror.c_str() );
         return("");
     }
     if ( txfee == 0 )

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -6157,6 +6157,7 @@ UniValue oraclesregister(const UniValue& params, bool fHelp)
     if ( (datafee= atol((char *)params[1].get_str().c_str())) == 0 )
         datafee = atof((char *)params[1].get_str().c_str()) * COIN + 0.00000000499999;
     hex = OracleRegister(0,txid,datafee);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6178,6 +6179,7 @@ UniValue oraclessubscribe(const UniValue& params, bool fHelp)
     pubkey = ParseHex(params[1].get_str().c_str());
     amount = atof((char *)params[2].get_str().c_str()) * COIN + 0.00000000499999;
     hex = OracleSubscribe(0,txid,pubkey2pk(pubkey),amount);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6211,6 +6213,9 @@ UniValue oraclesdata(const UniValue& params, bool fHelp)
     txid = Parseuint256((char *)params[0].get_str().c_str());
     data = ParseHex(params[1].get_str().c_str());
     hex = OracleData(0,txid,data);
+
+    RETURN_IF_ERROR(CCerror);
+
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6265,6 +6270,7 @@ UniValue oraclescreate(const UniValue& params, bool fHelp)
         return(result);
     }
     hex = OracleCreate(0,name,description,format);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5975,6 +5975,7 @@ UniValue gatewaysbind(const UniValue& params, bool fHelp)
         pubkeys.push_back(pubkey2pk(pubkey));
     }
     hex = GatewaysBind(0,coin,tokenid,totalsupply,oracletxid,M,N,pubkeys);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6004,6 +6005,8 @@ UniValue gatewaysdeposit(const UniValue& params, bool fHelp)
     if ( amount <= 0 || claimvout < 0 )
         throw runtime_error("invalid param: amount, numpks or claimvout\n");
     hex = GatewaysDeposit(0,bindtxid,height,coin,cointxid,claimvout,deposithex,proof,pubkey2pk(destpub),amount);
+
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6027,6 +6030,7 @@ UniValue gatewaysclaim(const UniValue& params, bool fHelp)
     destpub = ParseHex(params[3].get_str());
     amount = atof((char *)params[4].get_str().c_str()) * COIN + 0.00000000499999;
     hex = GatewaysClaim(0,bindtxid,coin,deposittxid,pubkey2pk(destpub),amount);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6049,6 +6053,7 @@ UniValue gatewayswithdraw(const UniValue& params, bool fHelp)
     withdrawpub = ParseHex(params[2].get_str());
     amount = atof((char *)params[3].get_str().c_str()) * COIN + 0.00000000499999;
     hex = GatewaysWithdraw(0,bindtxid,coin,pubkey2pk(withdrawpub),amount);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6070,6 +6075,7 @@ UniValue gatewaysmarkdone(const UniValue& params, bool fHelp)
     coin = params[1].get_str();
     cointxid = Parseuint256((char *)params[2].get_str().c_str());
     hex = GatewaysMarkdone(0,withdrawtxid,coin,cointxid);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));
@@ -6116,6 +6122,7 @@ UniValue gatewayspartialsign(const UniValue& params, bool fHelp)
     coin = params[1].get_str();
     parthex = params[2].get_str();
     hex = GatewaysPartialSign(0,txid,coin,parthex);
+    RETURN_IF_ERROR(CCerror);
     if ( hex.size() > 0 )
     {
         result.push_back(Pair("result", "success"));


### PR DESCRIPTION
This sets the stage, the main RPCs can now understand when any internals sets CCerror global. Much of the internals still need to learn to set CCerror, but a few common cases are implemented now.

