### PR TITLE
Tests for -ac_algo=verushash

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -11,6 +11,7 @@ export BITCOIND=${REAL_BITCOIND}
 #Run the tests
 
 testScripts=(
+    'verushash.py'
     'cryptoconditions.py'
     'paymentdisclosure.py'
     'prioritisetransaction.py'

--- a/qa/rpc-tests/verushash.py
+++ b/qa/rpc-tests/verushash.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python2
+# Copyright (c) 2018 SuperNET developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, assert_greater_than, \
+    initialize_chain_clean, initialize_chain, start_nodes, start_node, connect_nodes_bi, \
+    stop_nodes, sync_blocks, sync_mempools, wait_bitcoinds, rpc_port, assert_raises
+
+import time
+from decimal import Decimal
+from random import choice
+from string import ascii_uppercase
+
+def assert_success(result):
+    assert_equal(result['result'], 'success')
+
+def assert_error(result):
+    assert_equal(result['result'], 'error')
+
+def generate_random_string(length):
+    random_string = ''.join(choice(ascii_uppercase) for i in range(length))
+    return random_string
+
+
+class VerusHashTest (BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing VerusHash test directory "+self.options.tmpdir)
+        self.num_nodes = 2
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
+
+    def setup_network(self, split = False):
+        print("Setting up network...")
+        self.nodes   = start_nodes(self.num_nodes, self.options.tmpdir,
+                    extra_args=[[
+                    # always give -ac_name as first extra_arg and port as third
+                    '-ac_name=REGTEST',
+                    '-conf='+self.options.tmpdir+'/node0/REGTEST.conf',
+                    '-port=64367',
+                    '-rpcport=64368',
+                    '-regtest',
+                    '-addressindex=1',
+                    '-spentindex=1',
+                    '-ac_supply=5555555',
+                    '-ac_reward=10000000000000',
+                    '-ac_algo=verushash',
+                    '-ac_cc=2',
+                    '-whitelist=127.0.0.1',
+                    '-debug',
+                    '--daemon',
+                    '-rpcuser=rt',
+                    '-rpcpassword=rt'
+                    ],
+                    ['-ac_name=REGTEST',
+                    '-conf='+self.options.tmpdir+'/node1/REGTEST.conf',
+                    '-port=64365',
+                    '-rpcport=64366',
+                    '-regtest',
+                    '-addressindex=1',
+                    '-spentindex=1',
+                    '-ac_supply=5555555',
+                    '-ac_reward=10000000000000',
+                    '-ac_algo=verushash',
+                    '-ac_cc=2',
+                    '-whitelist=127.0.0.1',
+                    '-debug',
+                    '-addnode=127.0.0.1:64367',
+                    '--daemon',
+                    '-rpcuser=rt',
+                    '-rpcpassword=rt']]
+        )
+        self.is_network_split = split
+        self.rpc              = self.nodes[0]
+        self.rpc1             = self.nodes[1]
+        self.sync_all()
+        print("Done setting up network")
+
+    def send_and_mine(self, xtn, rpc_connection):
+        txid = rpc_connection.sendrawtransaction(xtn)
+        assert txid, 'got txid'
+        # we need the tx above to be confirmed in the next block
+        rpc_connection.generate(1)
+        return txid
+
+    def run_test (self):
+        print("Mining blocks...")
+        rpc     = self.nodes[0]
+        rpc1    = self.nodes[1]
+        # utxos from block 1 become mature in block 101
+        rpc.generate(101)
+        self.sync_all()
+        rpc.getinfo()
+        rpc1.getinfo()
+
+if __name__ == '__main__':
+    VerusHashTest ().main()


### PR DESCRIPTION
This new test file starts up 2 regtest nodes with VerusHash PoW algo:
```
Running /home/dukeleto/git/komodo/qa/pull-tester/run-bitcoin-cli -ac_name=REGTEST -conf=/tmp/testSt2Wx8/node1/REGTEST.conf -port=64365 -rpcport=64366 -regtest -addressindex=1 -spentindex=1 -ac_supply=5555555 -ac_reward=10000000000000 -ac_algo=verushash -ac_cc=2 -whitelist=127.0.0.1 -debug -addnode=127.0.0.1:64367 --daemon -rpcuser=rt -rpcpassword=rt -rpcwait getblockcount
ASSETCHAINS_ALGO, algorithm set to verushash
```
Currently the `generate` RPC dies with: 
```
ERA0: end.0 reward.10000000000000 halving.0 decay.0
0
connecting to http://rt:rt@127.0.0.1:64366
created proxy
Done setting up network
Mining blocks...
unexpected fname.(/tmp/testSt2Wx8/node0) vs REGTEST [REGTEST] n.7 len.21 (8/node0)
unexpected fname.(/tmp/testSt2Wx8/node0) vs REGTEST [REGTEST] n.7 len.21 (8/node0)
unexpected fname.(/tmp/testSt2Wx8/node1) vs REGTEST [REGTEST] n.7 len.21 (8/node1)
unexpected fname.(/tmp/testSt2Wx8/node1) vs REGTEST [REGTEST] n.7 len.21 (8/node1)
JSONRPC error: Division by zero
  File "/home/dukeleto/git/komodo/qa/rpc-tests/test_framework/test_framework.py", line 121, in main
    self.run_test()
  File "/home/dukeleto/git/komodo/qa/rpc-tests/verushash.py", line 93, in run_test
    rpc.generate(101)
  File "/home/dukeleto/git/komodo/qa/rpc-tests/test_framework/authproxy.py", line 145, in __call__
    raise JSONRPCException(response['error'])
```
It seems to mine 4 blocks correctly and then dies before the 5th block is successfully mined.

To run these tests: `./qa/pull-tester/rpc-tests.sh verushash`