### PR TITLE
Fsm

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -11,6 +11,7 @@ export BITCOIND=${REAL_BITCOIND}
 #Run the tests
 
 testScripts=(
+    'ac_private.py'
     'verushash.py'
     'cryptoconditions.py'
     'paymentdisclosure.py'

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -468,6 +468,7 @@ static const CRPCCommand vRPCCommands[] =
     { "tokens",       "tokencancelask",   &tokencancelask,    true },
     { "tokens",       "tokenfillask",     &tokenfillask,      true },
     //{ "tokens",       "tokenfillswap",    &tokenfillswap,     true },
+    { "tokens",       "tokenconvert", &tokenconvert, true },
 
     /* Address index */
     { "addressindex",       "getaddressmempool",      &getaddressmempool,      true  },


### PR DESCRIPTION
Fix the missing tokenconvert RPC and add in ac_private test.

To run this test: ./qa/pull-tester/rpc-tests.sh ac_private.py --tracerpc