### PR TITLE
Fix z_importkey

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -136,7 +136,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_shieldcoinbase", 3},
     { "z_getoperationstatus", 0},
     { "z_getoperationresult", 0},
-    { "z_importkey", 1 },
     { "paxprice", 4 },
     { "paxprices", 3 },
     { "paxpending", 0 },


### PR DESCRIPTION
`./src/komodo-cli z_importkey FOO "no"` tested on both sprout and sapling generates no errors.