### PR TITLE
genproclimit fix

### DIFF
--- a/src/assetchains
+++ b/src/assetchains
@@ -11,7 +11,7 @@ if [ -z "$delay" ]; then delay=20; fi
 ./listassetchainparams | while read args; do
   gen=""
   if [ $[RANDOM % 10] == 1 ]; then
-      gen=" -gen"
+      gen=" -gen -genproclimit=1"
   fi
 
   ./komodod $gen $args $overide_args -pubkey=$pubkey -addnode=$seed_ip &


### PR DESCRIPTION
by default when we start komodod only with -gen arg
genproclimit automatically become -1. this behaviour derived
from VRSC after last merge (as i remember, vrsc has -1 by default,
0 - for staking, and >= 1 - for mining and staking), so we need
to set genproclimit=1 if we pass gen and want to actually start
mining.