### PR TITLE
Add makefile and readme for CC dapps

### DIFF
--- a/src/cc/dapps/Makefile
+++ b/src/cc/dapps/Makefile
@@ -1,0 +1,11 @@
+# just type make to compile all dapps
+all: zmigrate oraclefeed
+
+zmigrate:
+	$(CC) zmigrate.c -o zmigrate -lm
+
+oraclefeed:
+	$(CC) oraclefeed.c -o oraclefeed -lm
+
+clean:
+	rm zmigrate oraclefeed

--- a/src/cc/dapps/README.md
+++ b/src/cc/dapps/README.md
@@ -1,0 +1,28 @@
+# CryptoCondition dApps
+
+## Compiling
+
+To compile all dapps in this directory:
+
+    make
+
+## zmigrate - Sprout to Sapling Migration dApp
+
+This tool converts Sprout zaddress funds into Sapling funds in a new Sapling address.
+
+### Usage
+
+    ./zmigrate zsaplingaddr
+
+The above command may need to be run multiple times to complete the process.
+
+This CLI implementation will be called by GUI wallets, average users do not
+need to worry about using this low-level tool.
+
+## oraclefeed - feed of price data using oracles
+
+### Usage
+
+    ./oraclefeed $ACNAME $ORACLETXID $MYPUBKEY $FORMAT $BINDTXID [refcoin_cli]
+
+Supported formats are L and Ihh. Price data from CoinDesk API.


### PR DESCRIPTION
I didn't see the `makedapps` script until after writing this Makefile

Features:
* Only compile dapps that have changed
* Recognized $CC environment variable to easily choose compiler
* make clean

The readme is mostly so that we have some nicely rendered developer docs for CC-based dApps on Github. They are a summary of the more detailed comments in source code.