### PR TITLE
Don't add z-tx to the mempool on block validation.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4705,7 +4705,7 @@ bool CheckBlock(int32_t *futureblockp,int32_t height,CBlockIndex *pindex,const C
                 CValidationState state;
                 CTransaction Tx;
                 const CTransaction &tx = (CTransaction)block.vtx[i];
-                if (tx.IsCoinBase() || ((i == (block.vtx.size() - 1)) && (ASSETCHAINS_STAKED && komodo_isPoS((CBlock *)&block) != 0)))
+                if (tx.IsCoinBase() || tx.vjoinsplit.size() != 0 || ((i == (block.vtx.size() - 1)) && (ASSETCHAINS_STAKED && komodo_isPoS((CBlock *)&block) != 0)))
                     continue;
                 Tx = tx;
                 if ( myAddtomempool(Tx, &state) == false ) // happens with out of order tx in block on resync


### PR DESCRIPTION
Causes needless slowdowns and error messages on chain sync. CC tx dont depend on z-tx and they can never be added to the mempool as the joinsplit requirements can never be met.