### PR TITLE
This fixes the last of the sync issues. 

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -761,6 +761,8 @@ CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, int32_t nHeight, 
 
 void komodo_broadcast(CBlock *pblock,int32_t limit)
 {
+    if (IsInitialBlockDownload())
+        return;
     int32_t n = 1;
     //fprintf(stderr,"broadcast new block t.%u\n",(uint32_t)time(NULL));
     {


### PR DESCRIPTION
Not sure why this is even being called on chain sync, but it is. I figured out how to get "net" debug prints, then synced 2 nodes from each other locally. Watching which commands were being sent and received. For some reason, the node that was syncing was sending entire blocks back to the node being synced from. Doing a search on the entire source code and disabling the send block calls one at a time lead me here, and once this was added the problem goes away. 