### PR TITLE
check for non-existing eval

### DIFF
--- a/src/cc/CCinclude.h
+++ b/src/cc/CCinclude.h
@@ -270,21 +270,22 @@ UniValue ValueFromAmount(const CAmount& amount);
 #define CCLOG_DEBUG3 3
 #define CCLOG_MAXLEVEL 3
 template <class T>
-inline void CCLogPrintStream(const char *category, int level, T print_to_stream)
+void CCLogPrintStream(const char *category, int level, T print_to_stream)
 {
-    std::ostringstream stream; 
+    std::ostringstream stream;
     print_to_stream(stream);
-    if (level < 0) 
-        level = 0; 
+    if (level < 0)
+        level = 0;
     if (level > CCLOG_MAXLEVEL)
         level = CCLOG_MAXLEVEL;
     for (int i = level; i <= CCLOG_MAXLEVEL; i++)
-        if (LogAcceptCategory((std::string(category) + (i > 0 ? std::string("-") + std::to_string(i) : std::string(""))).c_str()))   {
+        if( LogAcceptCategory((std::string(category) + std::string("-") + std::to_string(i)).c_str())  ||     // '-debug=cctokens-0', '-debug=cctokens-1',...
+            i == 0 && LogAcceptCategory(std::string(category).c_str()) )  {                                  // also supporting '-debug=cctokens' for CCLOG_INFO
             LogPrintStr(stream.str());
             break;
         }
 }
-
+// use: LOGSTREAM("yourcategory", your-debug-level, stream << "some log data" << data2 << data3 << ... << std::endl);
 #define LOGSTREAM(category, level, logoperator) CCLogPrintStream( category, level, [=](std::ostringstream &stream) {logoperator;} )
 
 

--- a/src/cc/CCtokens.cpp
+++ b/src/cc/CCtokens.cpp
@@ -253,7 +253,7 @@ bool TokensValidate(struct CCcontract_info *cp, Eval* eval, const CTransaction &
 	if ((funcid = DecodeTokenOpRet(tx.vout[numvouts - 1].scriptPubKey, evalCodeInOpret, tokenid, voutTokenPubkeys, vopretExtra)) == 0)
 		return eval->Invalid("TokenValidate: invalid opreturn payload");
 
-    LOGSTREAM((char *)"cctokens", CCLOG_INFO, stream << "TokensValidate funcId=" << (char)(funcid?funcid:' ') << " evalcode=" << cp->evalcode << std::endl);
+    LOGSTREAM((char *)"cctokens", CCLOG_INFO, stream << "TokensValidate funcId=" << (char)(funcid?funcid:' ') << " evalcode=" << std::hex << (int)cp->evalcode << std::endl);
 
     if (eval->GetTxUnconfirmed(tokenid, createTx, hashBlock) == 0)
 		return eval->Invalid("cant find token create txid");

--- a/src/cc/CCutils.cpp
+++ b/src/cc/CCutils.cpp
@@ -687,6 +687,9 @@ bool ProcessCC(struct CCcontract_info *cp,Eval* eval, std::vector<uint8_t> param
         from_mempool = 1;
         height &= ((1<<30) - 1);
     }
+    if (cp->validate == NULL)
+        return eval->Invalid("validation not supported for eval code");
+
     //fprintf(stderr,"KOMODO_CONNECTING.%d mempool.%d vs CCactive.%d\n",height,from_mempool,KOMODO_CCACTIVATE);
     // there is a chance CC tx is valid in mempool, but invalid when in block, so we cant filter duplicate requests. if any of the vins are spent, for example
     //txid = ctx.GetHash();

--- a/src/cc/eval.cpp
+++ b/src/cc/eval.cpp
@@ -85,6 +85,7 @@ bool Eval::Dispatch(const CC *cond, const CTransaction &txTo, unsigned int nIn)
         CCinit(cp,ecode);
         cp->didinit = 1;
     }
+
     switch ( ecode )
     {
         case EVAL_IMPORTPAYOUT:


### PR DESCRIPTION
added check if eval code not supported to prevent segfault in validation
in CCLogPrintStream -debug=cat-0 added