### PR TITLE
Decode token unmarshal fix

### DIFF
--- a/src/cc/heir.cpp
+++ b/src/cc/heir.cpp
@@ -327,16 +327,17 @@ uint8_t _DecodeHeirEitherOpRet(CScript scriptPubKey, uint256 &tokenid, CPubKey& 
 {
 	uint8_t evalCodeTokens = 0;
 	std::vector<CPubKey> voutPubkeysDummy;
-	std::vector<uint8_t> vopretExtra, vopretStripped;
+	std::vector<uint8_t> vopretExtra /*, vopretStripped*/;
 
 	if (DecodeTokenOpRet(scriptPubKey, evalCodeTokens, tokenid, voutPubkeysDummy, vopretExtra) != 0) {
 		if (vopretExtra.size() > 1) {
 			// restore the second opret:
 
-			if (!E_UNMARSHAL(vopretExtra, { ss >> vopretStripped; })) {  //strip string size
+			/* unmarshalled in DecodeTokenOpRet:
+            if (!E_UNMARSHAL(vopretExtra, { ss >> vopretStripped; })) {  //strip string size
 				if (!noLogging) std::cerr << "_DecodeHeirEitherOpret() could not unmarshal vopretStripped" << std::endl;
 				return (uint8_t)0;
-			}
+			}*/
 		}
 		else {
 			if (!noLogging) std::cerr << "_DecodeHeirEitherOpret() empty vopretExtra" << std::endl;
@@ -344,10 +345,10 @@ uint8_t _DecodeHeirEitherOpRet(CScript scriptPubKey, uint256 &tokenid, CPubKey& 
 		}
 	}
 	else 	{
-		GetOpReturnData(scriptPubKey, vopretStripped);
+		GetOpReturnData(scriptPubKey, vopretExtra);
 	}
     
-    return _DecodeHeirOpRet(vopretStripped, ownerPubkey, heirPubkey, inactivityTime, heirName, memo, fundingTxidInOpret, hasHeirSpendingBegun, noLogging);
+    return _DecodeHeirOpRet(vopretExtra, ownerPubkey, heirPubkey, inactivityTime, heirName, memo, fundingTxidInOpret, hasHeirSpendingBegun, noLogging);
 }
 
 // overload to decode opret in fundingtxid:

--- a/src/cc/heir.cpp
+++ b/src/cc/heir.cpp
@@ -330,16 +330,16 @@ uint8_t _DecodeHeirEitherOpRet(CScript scriptPubKey, uint256 &tokenid, CPubKey& 
 	std::vector<uint8_t> vopretExtra /*, vopretStripped*/;
 
 	if (DecodeTokenOpRet(scriptPubKey, evalCodeTokens, tokenid, voutPubkeysDummy, vopretExtra) != 0) {
-		if (vopretExtra.size() > 1) {
-			// restore the second opret:
+        /* if (vopretExtra.size() > 1) {
+            // restore the second opret:
 
-			/* unmarshalled in DecodeTokenOpRet:
+            /* unmarshalled in DecodeTokenOpRet:
             if (!E_UNMARSHAL(vopretExtra, { ss >> vopretStripped; })) {  //strip string size
-				if (!noLogging) std::cerr << "_DecodeHeirEitherOpret() could not unmarshal vopretStripped" << std::endl;
-				return (uint8_t)0;
-			}*/
-		}
-		else {
+                if (!noLogging) std::cerr << "_DecodeHeirEitherOpret() could not unmarshal vopretStripped" << std::endl;
+                return (uint8_t)0;
+            }
+        } */
+        if (vopretExtra.size() < 1) {
 			if (!noLogging) std::cerr << "_DecodeHeirEitherOpret() empty vopretExtra" << std::endl;
 			return (uint8_t)0;
 		}


### PR DESCRIPTION
As DecodeTokenOpret now returns additional opret without leading data size, fixed handling of this in heir cc