### PR TITLE
Fix building cclib on darwin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -572,7 +572,7 @@ komodod_LDADD += \
   $(LIBVERUS_CRYPTO) \
   $(LIBVERUS_PORTABLE_CRYPTO) \
   $(LIBZCASH_LIBS) \
-  libcc.so -lncurses
+  libcc.dylib -lncurses
 
 if ENABLE_PROTON
 komodod_LDADD += $(LIBBITCOIN_PROTON) $(PROTON_LIBS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -571,8 +571,14 @@ komodod_LDADD += \
   $(LIBBITCOIN_CRYPTO) \
   $(LIBVERUS_CRYPTO) \
   $(LIBVERUS_PORTABLE_CRYPTO) \
-  $(LIBZCASH_LIBS) \
-  libcc.dylib -lncurses
+  $(LIBZCASH_LIBS)
+
+if TARGET_DARWIN
+komodod_LDADD += libcc.dylib -lncurses
+else
+komodod_LDADD += libcc.so -lncurses
+endif
+
 
 if ENABLE_PROTON
 komodod_LDADD += $(LIBBITCOIN_PROTON) $(PROTON_LIBS)


### PR DESCRIPTION
Tested with

```
$ cc -v
Apple LLVM version 9.1.0 (clang-902.0.39.1)
Target: x86_64-apple-darwin17.5.0
```

and `gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.11)`, both build without error.