### PR TITLE
Add help docs for all -ac_* params of komodod

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -562,6 +562,36 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-metricsui", _("Set to 1 for a persistent metrics screen, 0 for sequential metrics output (default: 1 if running in a console, 0 otherwise)"));
         strUsage += HelpMessageOpt("-metricsrefreshtime", strprintf(_("Number of seconds between metrics refreshes (default: %u if running in a console, %u otherwise)"), 1, 600));
     }
+    strUsage += HelpMessageGroup(_("Komodo Asset Chain options:"));
+    strUsage += HelpMessageOpt("-ac_algo", _("Choose PoW mining algorithm, default is Equihash"));
+    strUsage += HelpMessageOpt("-ac_blocktime", _("Block time in seconds, default is 60"));
+    strUsage += HelpMessageOpt("-ac_cc", _("Cryptoconditions, default 0"));
+    strUsage += HelpMessageOpt("-ac_beam", _("BEAM integration"));
+    strUsage += HelpMessageOpt("-ac_coda", _("CODA integration"));
+    strUsage += HelpMessageOpt("-ac_cclib", _("Cryptoconditions dynamicly loadable library"));
+    strUsage += HelpMessageOpt("-ac_ccenable", _("Cryptoconditions to enable"));
+    strUsage += HelpMessageOpt("-ac_ccactivate", _("Block height to enable Cryptoconditions"));
+    strUsage += HelpMessageOpt("-ac_decay", _("Percentage of block reward decrease at each halving"));
+    strUsage += HelpMessageOpt("-ac_end", _("Block height at which block rewards will end"));
+    strUsage += HelpMessageOpt("-ac_eras", _("Block reward eras"));
+    strUsage += HelpMessageOpt("-ac_founders", _("Number of blocks between founders reward payouts"));
+    strUsage += HelpMessageOpt("-ac_halving", _("Number of blocks between each block reward halving"));
+    strUsage += HelpMessageOpt("-ac_name", _("Name of asset chain"));
+    strUsage += HelpMessageOpt("-ac_notarypay", _("Pay notaries, default 0"));
+    strUsage += HelpMessageOpt("-ac_perc", _("Percentage of block rewards paid to the founder"));
+    strUsage += HelpMessageOpt("-ac_private", _("Shielded transactions only (except coinbase + notaries), default is 0"));
+    strUsage += HelpMessageOpt("-ac_pubkey", _("Public key for receiving payments on the network"));
+    strUsage += HelpMessageOpt("-ac_public", _("Transparent transactions only, default 0"));
+    strUsage += HelpMessageOpt("-ac_reward", _("Block reward in satoshis, default is 0"));
+    strUsage += HelpMessageOpt("-ac_sapling", _("Sapling activation block height"));
+    strUsage += HelpMessageOpt("-ac_script", _("P2SH/multisig address to receive founders rewards"));
+    strUsage += HelpMessageOpt("-ac_staked", _("Percentage of blocks that are Proof-Of-Stake, default 0"));
+    strUsage += HelpMessageOpt("-ac_supply", _("Starting supply, default is 0"));
+    strUsage += HelpMessageOpt("-ac_timelockfrom", _("Timelocked coinbase start height"));
+    strUsage += HelpMessageOpt("-ac_timelockgte",  _("Timelocked coinbase minimum amount to be locked"));
+    strUsage += HelpMessageOpt("-ac_timelockto",   _("Timelocked coinbase stop height"));
+    strUsage += HelpMessageOpt("-ac_txpow", _("Enforce transaction-rate limit, default 0"));
+    strUsage += HelpMessageOpt("-ac_veruspos", _("Use Verus Proof-Of-Stake (-ac_veruspos=50) default 0"));
 
     return strUsage;
 }


### PR DESCRIPTION
I got tired of looking up AC params on various documentation websites, so now anyone using `komodod` can simply do `komodod --help` to see asset creation options. Currently looks like:

```
Komodo Asset Chain options:

  -ac_algo
       Choose PoW mining algorithm, default is Equihash

  -ac_blocktime
       Block time in seconds, default is 60

  -ac_cc
       Cryptoconditions, default 0

  -ac_beam
       BEAM integration

  -ac_coda
       CODA integration

  -ac_cclib
       Cryptoconditions dynamicly loadable library

  -ac_ccenable
       Cryptoconditions to enable

  -ac_ccactivate
       Block height to enable Cryptoconditions

  -ac_decay
       Percentage of block reward decrease at each halving

  -ac_end
       Block height at which block rewards will end

  -ac_eras
       Block reward eras

  -ac_founders
       Number of blocks between founders reward payouts

  -ac_halving
       Number of blocks between each block reward halving

  -ac_name
       Name of asset chain

  -ac_notarypay
       Pay notaries, default 0

  -ac_perc
       Percentage of block rewards paid to the founder

  -ac_private
       Shielded transactions only (except coinbase + notaries), default is 0

  -ac_pubkey
       Public key for receiving payments on the network

  -ac_public
       Transparent transactions only, default 0

  -ac_reward
       Block reward in satoshis, default is 0

  -ac_sapling
       Sapling activation block height

  -ac_script
       P2SH/multisig address to receive founders rewards

  -ac_staked
       Percentage of blocks that are Proof-Of-Stake, default 0

  -ac_supply
       Starting supply, default is 0

  -ac_timelockfrom
       Timelocked coinbase start height

  -ac_timelockgte
       Timelocked coinbase minimum amount to be locked

  -ac_timelockto
       Timelocked coinbase stop height

  -ac_txpow
       Enforce transaction-rate limit, default 0

  -ac_veruspos
       Use Verus Proof-Of-Stake (-ac_veruspos=50) default 0
```