### PR TITLE
Rearrange constants definition for readability of tutorial.

### DIFF
--- a/src/cc/customcc.h
+++ b/src/cc/customcc.h
@@ -14,11 +14,11 @@
  */
  
 std::string MYCCLIBNAME = (char *)"customcc";
+#define MYCCNAME "custom"
 
 #define EVAL_CUSTOM (EVAL_FAUCET2+1)
 #define CUSTOM_TXFEE 10000
 
-#define MYCCNAME "custom"
 
 #define RPC_FUNCS    \
     { (char *)MYCCNAME, (char *)"func0", (char *)"<parameter help>", 1, 1, '0', EVAL_CUSTOM }, \


### PR DESCRIPTION
Define the command line name -ac_cclib="customcc"
Then define the internal MYCCNAME "custom"