### PR TITLE
Custom asset chain client names

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -20,6 +20,7 @@
 #include "clientversion.h"
 
 #include "tinyformat.h"
+#include "util.h"
 
 #include <string>
 

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -34,7 +34,7 @@
  * for both bitcoind and bitcoin-core, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string CLIENT_NAME("MagicBean");
+const std::string CLIENT_NAME = GetArg("-ac_clientname", "MagicBean");
 
 /**
  * Client version number

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -571,6 +571,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-ac_cclib", _("Cryptoconditions dynamicly loadable library"));
     strUsage += HelpMessageOpt("-ac_ccenable", _("Cryptoconditions to enable"));
     strUsage += HelpMessageOpt("-ac_ccactivate", _("Block height to enable Cryptoconditions"));
+    strUsage += HelpMessageOpt("-ac_clientname", _("Full node client name, default 'MagicBean'"));
     strUsage += HelpMessageOpt("-ac_decay", _("Percentage of block reward decrease at each halving"));
     strUsage += HelpMessageOpt("-ac_end", _("Block height at which block rewards will end"));
     strUsage += HelpMessageOpt("-ac_eras", _("Block reward eras"));


### PR DESCRIPTION
Hush has set a custom client name in the past (originally BalefulStatic chosen by radix42 and AuspiciousHerald for dpow-enabled clients) and would like to continue in that tradition and allow other asset chains to do the same. Hush plans to have some source-level changes so a custom client name makes sense. Asset chains which are purely run-time forks are recommended to keep the default value.

LABS nodes may also want to identify themselves via custom client names.