### PR TITLE
moving block from buffer horizontally if it not fit game field on swap

### DIFF
--- a/src/cc/games/tetris.c
+++ b/src/cc/games/tetris.c
@@ -296,6 +296,7 @@ static void tg_hold(struct games_state *rs,tetris_game *obj)
         obj->stored.ori = ori;
         while (!tg_fits(obj, obj->falling)) {
             obj->falling.loc.row--;
+            obj->falling.loc.col--;
         }
     }
     tg_put(obj, obj->falling);


### PR DESCRIPTION
There was an edge case with tetris game hang (when trying to swap block close to the game field edge and block not fits game field horizontally)