### PR TITLE
Equihash N_K for AC

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -152,7 +152,8 @@ public:
         BOOST_STATIC_ASSERT(equihash_parameters_acceptable(N, K));
         nEquihashN = N;
         nEquihashK = K;
-
+        // nEquihashN = N2;
+        // nEquihashK = K2;
         const char* pszTimestamp = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks";
         CMutableTransaction txNew;
         txNew.vin.resize(1);


### PR DESCRIPTION
Can allow AC to change these parameters without changing the kernel code?  if ( ASSETCHAINS_N != 200 ||  ASSETCHAINS_K != 9... nEquihashN = N2...  ? (+ edit pow, miner, equihash and others files for this future)