### PR TITLE
Change oraclessamples rpc to show txid for each

### DIFF
--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -959,7 +959,7 @@ UniValue OracleDataSamples(uint256 reforacletxid,uint256 batontxid,int32_t num)
                     a.push_back(uint256_str(str,batontxid));
                     b.push_back(a);
                     batontxid = btxid;
-                    if ( ++n >= num )
+                    if ( ++n >= num && num != 0)
                         break;
                 } else break;
             }

--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -935,13 +935,13 @@ UniValue OracleFormat(uint8_t *data,int32_t datalen,char *format,int32_t formatl
         if ( j >= datalen )
             break;
     }
-    return(obj);
+    return(str);
 }
 
 UniValue OracleDataSamples(uint256 reforacletxid,uint256 batontxid,int32_t num)
 {
-    UniValue result(UniValue::VOBJ),a(UniValue::VARR); CTransaction tx,oracletx; uint256 hashBlock,btxid,oracletxid; 
-    CPubKey pk; std::string name,description,format; int32_t numvouts,n=0; std::vector<uint8_t> data; char *formatstr = 0;
+    UniValue result(UniValue::VOBJ),b(UniValue::VARR); CTransaction tx,oracletx; uint256 hashBlock,btxid,oracletxid; 
+    CPubKey pk; std::string name,description,format; int32_t numvouts,n=0; std::vector<uint8_t> data; char str[67], *formatstr = 0;
     
     result.push_back(Pair("result","success"));
     if ( GetTransaction(reforacletxid,oracletx,hashBlock,false) != 0 && (numvouts=oracletx.vout.size()) > 0 )
@@ -954,7 +954,10 @@ UniValue OracleDataSamples(uint256 reforacletxid,uint256 batontxid,int32_t num)
                 {
                     if ( (formatstr= (char *)format.c_str()) == 0 )
                         formatstr = (char *)"";
+                    UniValue a(UniValue::VARR);
                     a.push_back(OracleFormat((uint8_t *)data.data(),(int32_t)data.size(),formatstr,(int32_t)format.size()));
+                    a.push_back(uint256_str(str,batontxid));
+                    b.push_back(a);
                     batontxid = btxid;
                     if ( ++n >= num )
                         break;
@@ -962,7 +965,7 @@ UniValue OracleDataSamples(uint256 reforacletxid,uint256 batontxid,int32_t num)
             }
         }
     }
-    result.push_back(Pair("samples",a));
+    result.push_back(Pair("samples",b));
     return(result);
 }
 


### PR DESCRIPTION
With the current oraclessamples rpc I could find no reliable way to match a given sample with it's txid. I need this functionality for LABS NN voting dapp. If there are any bad practices/noob mistakes in this code, please let me know prior to merging it. 
Previous behavior:
```
komodo-cli -ac_name=TXOR oraclessamples 10064b11c07a7d3468bbe5def3b74751389e2cf1858dfb4f3185168843b95b93 fe8844be79c201bb7ac69d207f7b90054ba044a43b6efbb832b91970d62bc3d4 10
{
  "result": "success",
  "samples": [
    [
      "do the thing"
    ],
    [
      "do all the things"
    ],
    [
      "do the other thing"
    ],
    [
      "subjective"
    ],
    [
      "subjective"
    ]
  ]
}
```

new behavior:
```
komodo-cli -ac_name=TXOR oraclessamples 10064b11c07a7d3468bbe5def3b74751389e2cf1858dfb4f3185168843b95b93 fe8844be79c201bb7ac69d207f7b90054ba044a43b6efbb832b91970d62bc3d4 10
{
  "result": "success",
  "samples": [
    [
      "do the thing",
      "fe8844be79c201bb7ac69d207f7b90054ba044a43b6efbb832b91970d62bc3d4"
    ],
    [
      "do all the things",
      "8987da1c6ee6823fb7302294e91dfa747aeec1d783263e06a73a30de20937a4d"
    ],
    [
      "do the other thing",
      "42656ec681b4ddabc4652b2e063df854e7c59f224f63d20ceca1e05125d0b432"
    ],
    [
      "subjective",
      "aa383ad5c9eb0db160382d11e3333838bdb03f393b330cced61edcbe69c9db90"
    ],
    [
      "subjective",
      "ca4f35f5e416f3af662f0e455538afac4be4a120fb4db8dc9591f5f91da26caf"
    ]
  ]
}
```

The samples were left as array to have minimal impact on existing oracles based dapps.
