### PR TITLE
change oraclessamples output to obj

### DIFF
--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -924,14 +924,13 @@ std::string OracleData(int64_t txfee,uint256 oracletxid,std::vector <uint8_t> da
 
 UniValue OracleFormat(uint8_t *data,int32_t datalen,char *format,int32_t formatlen)
 {
-    UniValue obj(UniValue::VARR); uint256 hash; int32_t i,j=0; int64_t val; char str[IGUANA_MAXSCRIPTSIZE*2+1];
+    uint256 hash; int32_t i,j=0; int64_t val; char str[IGUANA_MAXSCRIPTSIZE*2+1];
     for (i=0; i<formatlen && j<datalen; i++)
     {
         str[0] = 0;
         j = oracle_format(&hash,&val,str,format[i],data,j,datalen);
         if ( j < 0 )
             break;
-        obj.push_back(str);
         if ( j >= datalen )
             break;
     }
@@ -957,7 +956,6 @@ UniValue OracleDataSamples(uint256 reforacletxid,uint256 batontxid,int32_t num)
                     UniValue a(UniValue::VOBJ);
                     a.push_back(Pair("data",OracleFormat((uint8_t *)data.data(),(int32_t)data.size(),formatstr,(int32_t)format.size())));
                     a.push_back(Pair("txid",uint256_str(str,batontxid)));
-                    fprintf(stderr,"blahblahblahb.%s", uint256_str(str,batontxid));
                     b.push_back(a);
                     batontxid = btxid;
                     if ( ++n >= num && num != 0)

--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -954,9 +954,10 @@ UniValue OracleDataSamples(uint256 reforacletxid,uint256 batontxid,int32_t num)
                 {
                     if ( (formatstr= (char *)format.c_str()) == 0 )
                         formatstr = (char *)"";
-                    UniValue a(UniValue::VARR);
-                    a.push_back(OracleFormat((uint8_t *)data.data(),(int32_t)data.size(),formatstr,(int32_t)format.size()));
-                    a.push_back(uint256_str(str,batontxid));
+                    UniValue a(UniValue::VOBJ);
+                    a.push_back(Pair("data",OracleFormat((uint8_t *)data.data(),(int32_t)data.size(),formatstr,(int32_t)format.size())));
+                    a.push_back(Pair("txid",uint256_str(str,batontxid)));
+                    fprintf(stderr,"blahblahblahb.%s", uint256_str(str,batontxid));
                     b.push_back(a);
                     batontxid = btxid;
                     if ( ++n >= num && num != 0)


### PR DESCRIPTION
current behavior: 
```
komodo-cli -ac_name=ORT oraclessamples d6931f30ce2c07d9de17566cf41a1f0e908099beaadc5ded4b8ce7271efe9e9d RXcXipw2fTt8kencYXmEGSuikfEB3WiSnU 10
{
  "result": "success",
  "samples": [
    [
      "derp",
      "e6a2bef640f4f0b98809d5abab46c36a28f0f97843befbfea34711bdf4378713"
    ],
    [
      "herpp",
      "2103862663aadaeb473afae0c22c885fd3bfdffdba6c7c18bd903ffe944a6383"
    ]
  ]
}
```
new behavior: 
```
komodo-cli -ac_name=ORT oraclessamples d6931f30ce2c07d9de17566cf41a1f0e908099beaadc5ded4b8ce7271efe9e9d RXcXipw2fTt8kencYXmEGSuikfEB3WiSnU 10
{
  "result": "success",
  "samples": [
    {
      "data": "derp",
      "txid": "e6a2bef640f4f0b98809d5abab46c36a28f0f97843befbfea34711bdf4378713"
    },
    {
      "data": "herpp",
      "txid": "2103862663aadaeb473afae0c22c885fd3bfdffdba6c7c18bd903ffe944a6383"
    }
  ]
}
```

This allows us to add additional fields in the future without breaking existing dapps. This will break existing dapps right now, but now is a good time to include this as Mihailo will be changing the behavior of the `oraclessamples` rpc command to accept baton address instead of baton txid. 