### PR TITLE
Add the ability to import different WIF formats

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -207,6 +207,22 @@ CKey DecodeSecret(const std::string& str)
     return key;
 }
 
+CKey DecodeCustomSecret(const std::string& str, uint8_t secret_key)
+{
+    CKey key;
+    std::vector<unsigned char> data;
+    if (DecodeBase58Check(str, data)) {
+        const std::vector<unsigned char>& privkey_prefix = std::vector<unsigned char>(1, secret_key);
+        if ((data.size() == 32 + privkey_prefix.size() || (data.size() == 33 + privkey_prefix.size() && data.back() == 1)) &&
+            std::equal(privkey_prefix.begin(), privkey_prefix.end(), data.begin())) {
+            bool compressed = data.size() == 33 + privkey_prefix.size();
+            key.Set(data.begin() + privkey_prefix.size(), data.begin() + privkey_prefix.size() + 32, compressed);
+        }
+    }
+    memory_cleanse(data.data(), data.size());
+    return key;
+}
+
 std::string EncodeSecret(const CKey& key)
 {
     assert(key.IsValid());

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -17,6 +17,7 @@
 #include <string>
 
 CKey DecodeSecret(const std::string& str);
+CKey DecodeCustomSecret(const std::string& str, uint8_t secret_key);
 std::string EncodeSecret(const CKey& key);
 std::string EncodeCustomSecret(const CKey& key,uint8_t secret_key);
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -109,6 +109,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "lockunspent", 1 },
     { "importprivkey", 2 },
     { "importprivkey", 3 },
+    { "importprivkey", 4 },
     { "importaddress", 2 },
     { "verifychain", 0 },
     { "verifychain", 1 },

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -96,13 +96,14 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
 
     if (fHelp || params.size() < 1 || params.size() > 5)
         throw runtime_error(
-            "importprivkey \"komodoprivkey\" ( \"label\" rescan height)\n"
+            "importprivkey \"komodoprivkey\" ( \"label\" rescan height secret_key)\n"
             "\nAdds a private key (as returned by dumpprivkey) to your wallet.\n"
             "\nArguments:\n"
             "1. \"komodoprivkey\"   (string, required) The private key (see dumpprivkey)\n"
             "2. \"label\"            (string, optional, default=\"\") An optional label\n"
             "3. rescan               (boolean, optional, default=true) Rescan the wallet for transactions\n"
             "4. height               (integer, optional, default=0) start at block height?\n"
+            "5. secret_key           (interger, optional, default=188) used to import WIFs of other coins\n" 
             "\nNote: This call can take minutes to complete if rescan is true.\n"
             "\nExamples:\n"
             "\nDump a private key\n"
@@ -115,6 +116,10 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", false") +
             "\nImport with rescan from a block height\n"
             + HelpExampleCli("importprivkey", "\"mykey\" \"testing\" true 1000") +
+            "\nImport a BTC WIF with rescan\n"
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" true 0 128") +
+            "\nImport a BTC WIF without rescan\n"
+            + HelpExampleCli("importprivkey", "\"BTCWIF\" \"testing\" false 0 128") +
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", true, 1000")
         );

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -127,6 +127,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     string strLabel = "";
     int32_t height = 0;
     uint8_t secret_key = 0;
+    CKey key;
     if (params.size() > 1)
         strLabel = params[1].get_str();
 
@@ -137,12 +138,13 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     if ( fRescan && params.size() == 4 )
         height = params[3].get_int();
 
-    CKey key = DecodeSecret(strSecret);
 
     if (params.size() > 4)
     {
-        secret_key = params[4].get_int();
-        CKey key = DecodeCustomSecret(strSecret, secret_key);
+        auto secret_key = AmountFromValue(params[4])/100000000;
+        key = DecodeCustomSecret(strSecret, secret_key);
+    } else {
+        key = DecodeSecret(strSecret);
     }
 
     if ( height < 0 || height > chainActive.Height() )

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -94,7 +94,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    if (fHelp || params.size() < 1 || params.size() > 4)
+    if (fHelp || params.size() < 1 || params.size() > 5)
         throw runtime_error(
             "importprivkey \"komodoprivkey\" ( \"label\" rescan height)\n"
             "\nAdds a private key (as returned by dumpprivkey) to your wallet.\n"
@@ -126,6 +126,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     string strSecret = params[0].get_str();
     string strLabel = "";
     int32_t height = 0;
+    uint8_t secret_key = 0;
     if (params.size() > 1)
         strLabel = params[1].get_str();
 
@@ -136,10 +137,17 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     if ( fRescan && params.size() == 4 )
         height = params[3].get_int();
 
+    CKey key = DecodeSecret(strSecret);
+
+    if (params.size() > 4)
+    {
+        secret_key = params[4].get_int();
+        CKey key = DecodeCustomSecret(strSecret, secret_key);
+    }
+
     if ( height < 0 || height > chainActive.Height() )
         throw JSONRPCError(RPC_WALLET_ERROR, "Rescan height is out of range.");
     
-    CKey key = DecodeSecret(strSecret);
     if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
 
     CPubKey pubkey = key.GetPubKey();


### PR DESCRIPTION
This adds the ability to import WIFs of different SECRET_KEY formats directly to komodod. This is useful in the event of airdrops. It adds an additional optional argument to the `importprivkey` rpc command, `secret_key`. This value can typically be found in `chainparams.cpp` of a coin.
For example, to import a BTC WIF, the command would be: 
`komodo-cli importprivkey <BTCWIF> "label" false 0 128`

128 being the SECRET_KEY value found here,  https://github.com/bitcoin/bitcoin/blob/1212808762f63185bbde980c154d3e1a6c6eb819/src/chainparams.cpp#L134