### PR TITLE
Avoid downloading 700MB groth16 params that we do not need

### DIFF
--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -6,7 +6,7 @@ $(package)_download_file=$($(package)_git_commit).tar.gz
 $(package)_sha256_hash=9909ec59fa7a411c2071d6237b3363a0bc6e5e42358505cf64b7da0f58a7ff5a
 $(package)_git_commit=06da3b9ac8f278e5d4ae13088cf0a4c03d2c13f5
 $(package)_dependencies=rust $(rust_crates)
-$(package)_patches=cargo.config 0001-Start-using-cargo-clippy-for-CI.patch remove-dev-dependencies.diff
+$(package)_patches=cargo.config 0001-Start-using-cargo-clippy-for-CI.patch remove-dev-dependencies.diff no-groth16.patch
 
 ifeq ($(host_os),mingw32)
 $(package)_library_file=target/x86_64-pc-windows-gnu/release/rustzcash.lib

--- a/depends/patches/librustzcash/no-groth16.patch
+++ b/depends/patches/librustzcash/no-groth16.patch
@@ -1,0 +1,113 @@
+diff --git a/librustzcash/src/rustzcash.rs b/librustzcash/src/rustzcash.rs
+index da448b0..4503ec9 100644
+--- a/librustzcash/src/rustzcash.rs
++++ b/librustzcash/src/rustzcash.rs
+@@ -181,6 +181,8 @@ pub extern "system" fn librustzcash_init_zksnark_params(
+     )
+ }
+ 
++// We ignore the values of sprout_path/sprout_hash but keep
++// same function signature for convenience
+ fn init_zksnark_params(
+     spend_path: &Path,
+     spend_hash: *const c_char,
+@@ -205,7 +207,8 @@ fn init_zksnark_params(
+         .expect("hash should be a valid string");
+ 
+     // Load params
+-    let (spend_params, spend_vk, output_params, output_vk, sprout_vk) = load_parameters(
++    //let (spend_params, spend_vk, output_params, output_vk, sprout_vk) = load_parameters(
++    let (spend_params, spend_vk, output_params, output_vk) = load_parameters(
+         spend_path,
+         spend_hash,
+         output_path,
+@@ -223,7 +226,7 @@ fn init_zksnark_params(
+ 
+         SAPLING_SPEND_VK = Some(spend_vk);
+         SAPLING_OUTPUT_VK = Some(output_vk);
+-        SPROUT_GROTH16_VK = Some(sprout_vk.unwrap());
++        //SPROUT_GROTH16_VK = Some(sprout_vk.unwrap());
+     }
+ }
+ 
+@@ -864,7 +867,7 @@ pub extern "system" fn librustzcash_sprout_prove(
+     )
+     .expect("couldn't load Sprout groth16 parameters file");
+ 
+-    let mut sprout_fs = BufReader::with_capacity(1024 * 1024, sprout_fs);
++    //let mut sprout_fs = BufReader::with_capacity(1024 * 1024, sprout_fs);
+ 
+     let params = Parameters::<Bls12>::read(&mut sprout_fs, false)
+         .expect("couldn't deserialize Sprout JoinSplit parameters file");
+diff --git a/zcash_proofs/src/lib.rs b/zcash_proofs/src/lib.rs
+index ca17a8b..36f89d3 100644
+--- a/zcash_proofs/src/lib.rs
++++ b/zcash_proofs/src/lib.rs
+@@ -32,14 +32,12 @@ pub fn load_parameters(
+     // Load from each of the paths
+     let spend_fs = File::open(spend_path).expect("couldn't load Sapling spend parameters file");
+     let output_fs = File::open(output_path).expect("couldn't load Sapling output parameters file");
+-    let sprout_fs =
+-        sprout_path.map(|p| File::open(p).expect("couldn't load Sprout groth16 parameters file"));
++    //let sprout_fs = sprout_path.map(|p| File::open(p).expect("couldn't load Sprout groth16 parameters file"));
+ 
+     let mut spend_fs = hashreader::HashReader::new(BufReader::with_capacity(1024 * 1024, spend_fs));
+     let mut output_fs =
+         hashreader::HashReader::new(BufReader::with_capacity(1024 * 1024, output_fs));
+-    let mut sprout_fs =
+-        sprout_fs.map(|fs| hashreader::HashReader::new(BufReader::with_capacity(1024 * 1024, fs)));
++    //let mut sprout_fs = sprout_fs.map(|fs| hashreader::HashReader::new(BufReader::with_capacity(1024 * 1024, fs)));
+ 
+     // Deserialize params
+     let spend_params = Parameters::<Bls12>::read(&mut spend_fs, false)
+@@ -50,10 +48,10 @@ pub fn load_parameters(
+     // We only deserialize the verifying key for the Sprout parameters, which
+     // appears at the beginning of the parameter file. The rest is loaded
+     // during proving time.
+-    let sprout_vk = sprout_fs.as_mut().map(|mut fs| {
+-        VerifyingKey::<Bls12>::read(&mut fs)
+-            .expect("couldn't deserialize Sprout Groth16 verifying key")
+-    });
++    //let sprout_vk = sprout_fs.as_mut().map(|mut fs| {
++    //    VerifyingKey::<Bls12>::read(&mut fs)
++    //        .expect("couldn't deserialize Sprout Groth16 verifying key")
++    //});
+ 
+     // There is extra stuff (the transcript) at the end of the parameter file which is
+     // used to verify the parameter validity, but we're not interested in that. We do
+@@ -64,10 +62,10 @@ pub fn load_parameters(
+         .expect("couldn't finish reading Sapling spend parameter file");
+     io::copy(&mut output_fs, &mut sink)
+         .expect("couldn't finish reading Sapling output parameter file");
+-    if let Some(mut sprout_fs) = sprout_fs.as_mut() {
+-        io::copy(&mut sprout_fs, &mut sink)
+-            .expect("couldn't finish reading Sprout groth16 parameter file");
+-    }
++    //if let Some(mut sprout_fs) = sprout_fs.as_mut() {
++    //    io::copy(&mut sprout_fs, &mut sink)
++    //        .expect("couldn't finish reading Sprout groth16 parameter file");
++    //}
+ 
+     if spend_fs.into_hash() != spend_hash {
+         panic!("Sapling spend parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
+@@ -77,14 +75,15 @@ pub fn load_parameters(
+         panic!("Sapling output parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
+     }
+ 
+-    if sprout_fs.map(|fs| fs.into_hash()) != sprout_hash.map(|h| h.to_owned()) {
+-        panic!("Sprout groth16 parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
+-    }
++    //if sprout_fs.map(|fs| fs.into_hash()) != sprout_hash.map(|h| h.to_owned()) {
++    //    panic!("Sprout groth16 parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
++    //}
+ 
+     // Prepare verifying keys
+     let spend_vk = prepare_verifying_key(&spend_params.vk);
+     let output_vk = prepare_verifying_key(&output_params.vk);
+-    let sprout_vk = sprout_vk.map(|vk| prepare_verifying_key(&vk));
++    //let sprout_vk = sprout_vk.map(|vk| prepare_verifying_key(&vk));
+ 
+-    (spend_params, spend_vk, output_params, output_vk, sprout_vk)
++    //(spend_params, spend_vk, output_params, output_vk, sprout_vk)
++    (spend_params, spend_vk, output_params, output_vk)
+ }

--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -32,14 +32,12 @@ int main(int argc, char **argv) {
 
   boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
   boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
-  boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
 
     static_assert(
         sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
         "librustzcash not configured correctly");
     auto sapling_spend_str = sapling_spend.native();
     auto sapling_output_str = sapling_output.native();
-    auto sprout_groth16_str = sprout_groth16.native();
 
     librustzcash_init_zksnark_params(
         reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
@@ -48,9 +46,9 @@ int main(int argc, char **argv) {
         reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
         sapling_output_str.length(),
         "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
-        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
-        sprout_groth16_str.length(),
-        "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
+        "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028"
     );
 
   testing::InitGoogleMock(&argc, argv);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -756,14 +756,12 @@ static void ZC_LoadParams(
     boost::filesystem::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
     boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
     boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
-    boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
 
     if (!(
         boost::filesystem::exists(pk_path) &&
         boost::filesystem::exists(vk_path) &&
         boost::filesystem::exists(sapling_spend) &&
-        boost::filesystem::exists(sapling_output) &&
-        boost::filesystem::exists(sprout_groth16)
+        boost::filesystem::exists(sapling_output)
     )) {
         uiInterface.ThreadSafeMessageBox(strprintf(
             _("Cannot find the Zcash network parameters in the following directory:\n"
@@ -789,11 +787,9 @@ static void ZC_LoadParams(
         "librustzcash not configured correctly");
     auto sapling_spend_str = sapling_spend.native();
     auto sapling_output_str = sapling_output.native();
-    auto sprout_groth16_str = sprout_groth16.native();
 
     LogPrintf("Loading Sapling (Spend) parameters from %s\n", sapling_spend.string().c_str());
     LogPrintf("Loading Sapling (Output) parameters from %s\n", sapling_output.string().c_str());
-    LogPrintf("Loading Sapling (Sprout Groth16) parameters from %s\n", sprout_groth16.string().c_str());
     gettimeofday(&tv_start, 0);
 
     librustzcash_init_zksnark_params(
@@ -803,9 +799,10 @@ static void ZC_LoadParams(
         reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
         sapling_output_str.length(),
         "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
-        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
-        sprout_groth16_str.length(),
-        "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
+	// These are dummy arguments, ignored by Hush-flavored librustzcash
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
+        "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028"
     );
 
     gettimeofday(&tv_end, 0);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -44,14 +44,12 @@ JoinSplitTestingSetup::JoinSplitTestingSetup()
 
     boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
     boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
-    boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
 
     static_assert(
         sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
         "librustzcash not configured correctly");
     auto sapling_spend_str = sapling_spend.native();
     auto sapling_output_str = sapling_output.native();
-    auto sprout_groth16_str = sprout_groth16.native();
 
     librustzcash_init_zksnark_params(
         reinterpret_cast<const codeunit*>(sapling_spend_str.c_str()),
@@ -60,9 +58,9 @@ JoinSplitTestingSetup::JoinSplitTestingSetup()
         reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
         sapling_output_str.length(),
         "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
-        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
-        sprout_groth16_str.length(),
-        "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
+        reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
+        sapling_output_str.length(),
+        "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028"
     );
 }
 

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -12,9 +12,8 @@ SPROUT_PKEY_NAME='sprout-proving.key'
 SPROUT_VKEY_NAME='sprout-verifying.key'
 SAPLING_SPEND_NAME='sapling-spend.params'
 SAPLING_OUTPUT_NAME='sapling-output.params'
-SAPLING_SPROUT_GROTH16_NAME='sprout-groth16.params'
-SPROUT_URL="https://z.cash/downloads"
-SPROUT_IPFS="/ipfs/QmZKKx7Xup7LiAtFRhYsE1M7waXcv9ir9eCECyXAFGxhEo"
+URL="https://z.cash/downloads"
+IPFS="/ipfs/QmZKKx7Xup7LiAtFRhYsE1M7waXcv9ir9eCECyXAFGxhEo"
 
 SHA256CMD="$(command -v sha256sum || echo shasum)"
 SHA256ARGS="$(command -v sha256sum >/dev/null || echo '-a 256')"
@@ -38,7 +37,7 @@ function fetch_wget {
 
     cat <<EOF
 
-Retrieving (wget): $SPROUT_URL/$filename
+Retrieving (wget): $URL/$filename
 EOF
 
     wget \
@@ -46,7 +45,7 @@ EOF
         --output-document="$dlname" \
         --continue \
         --retry-connrefused --waitretry=3 --timeout=30 \
-        "$SPROUT_URL/$filename"
+        "$URL/$filename"
 }
 
 function fetch_ipfs {
@@ -75,20 +74,20 @@ function fetch_curl {
 
     cat <<EOF
 
-Retrieving (curl): $SPROUT_URL/$filename
+Retrieving (curl): $URL/$filename
 EOF
 
     curl \
         --output "$dlname" \
         -# -L -C - \
-        "$SPROUT_URL/$filename"
+        "$URL/$filename"
 
 }
 
 function fetch_failure {
     cat >&2 <<EOF
 
-Failed to fetch the Zcash zkSNARK parameters!
+Failed to fetch the Komodo zkSNARK parameters!
 Try installing one of the following programs and make sure you're online:
 
  * ipfs
@@ -159,9 +158,9 @@ function main() {
     || exit_locked_error
 
     cat <<EOF
-Zcash - fetch-params.sh
+Komodo - fetch-params.sh
 
-This script will fetch the Zcash zkSNARK parameters and verify their
+This script will fetch the zkSNARK parameters and verify their
 integrity with sha256sum.
 
 If they already exist locally, it will exit now and do nothing else.
@@ -182,7 +181,7 @@ EOF
         # This may be the first time the user's run this script, so give
         # them some info, especially about bandwidth usage:
         cat <<EOF
-The parameters are currently just under 911MB in size, so plan accordingly
+The parameters are currently about 960MB in size, so plan accordingly
 for your bandwidth constraints. If the files are already present and
 have the correct sha256sum, no networking is used.
 
@@ -201,7 +200,7 @@ EOF
     # Sapling parameters:
     fetch_params "$SAPLING_SPEND_NAME" "$PARAMS_DIR/$SAPLING_SPEND_NAME" "8e48ffd23abb3a5fd9c5589204f32d9c31285a04b78096ba40a79b75677efc13"
     fetch_params "$SAPLING_OUTPUT_NAME" "$PARAMS_DIR/$SAPLING_OUTPUT_NAME" "2f0ebbcbb9bb0bcffe95a397e7eba89c29eb4dde6191c339db88570e3f3fb0e4"
-    fetch_params "$SAPLING_SPROUT_GROTH16_NAME" "$PARAMS_DIR/$SAPLING_SPROUT_GROTH16_NAME" "b685d700c60328498fbde589c8c7c484c722b788b265b72af448a5bf0ee55b50"
+
 }
 
 main


### PR DESCRIPTION
NOTE: Work in progress, needs more testing before merging.

This is a port of this from the Hush codebase. I had to make some manual changes in fetch-params, which is different since Hush does not download any sprout files.

With this change, every KMD asset chain full node no longer must download 700MB file it does not use. This greatly benefits people with slow/expensive internet and mobile use cases.

There is no way to accomplish this task without modifying Rust code in librustzcash. I tried all other ways, but it's not possible. The current code implements a simple patch on top of librustzcash, which the build system knows how to apply. This means we still use upstream ZEC librustzcash releases, and we don't need to change all the URLs and SHA256 hashes in our build system. 

Once users have the new code, they can free up disk space by deleting the groth16 file, if they want:

`rm ~/.zcash-params/sprout-groth16.params`

To fully test this, a full sync of Pirate and any other asset chains which have joinsplits should be done. If anybody can help, that would be great, otherwise it will take me a few days. /cc @radix42

FYI, for Pirate SevenSeas to work with this, just 2 lines need to be deleted, the one that checks for the groth16 file and the line which downloads it.