### PR TITLE
payments cc fix

### DIFF
--- a/src/cc/payments.cpp
+++ b/src/cc/payments.cpp
@@ -75,6 +75,36 @@
  
 */
 
+// payments cc fix
+#if (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+    #undef mpz_set_si
+    #undef mpz_get_si
+    #define GMP_LIMB_HIGHBIT ((mp_limb_t) 1 << (GMP_LIMB_BITS - 1))
+    #define GMP_NEG_CAST(T,x) (-(int64_t)((T)((x) + 1) - 1))
+
+    int64_t mpz_get_si (const mpz_t u) 
+        {
+        mp_size_t us = u->_mp_size;
+        if (us > 0)
+            return (int64_t) (u->_mp_d[0] & ~GMP_LIMB_HIGHBIT);
+        else if (us < 0)
+            return (int64_t) (- u->_mp_d[0] | GMP_LIMB_HIGHBIT);
+        else
+            return 0;
+    }
+
+    void mpz_set_si (mpz_t r, int64_t x)
+    {
+        if (x >= 0)
+            mpz_set_ui (r, x);
+        else /* (x < 0) */
+        {
+            r->_mp_size = -1;
+            r->_mp_d[0] = GMP_NEG_CAST (uint64_t, x);
+        }
+    }
+#endif
+
 // start of consensus code
 
 CScript EncodePaymentsTxidOpRet(int64_t allocation,std::vector<uint8_t> scriptPubKey,std::vector<uint8_t> destopret)


### PR DESCRIPTION
@Alrighttt comes to me with the an issue description from one of cc payments chains on Windows OS.

After investigation what's wrong i've found that it uses gmp library and this https://github.com/jl777/komodo/blob/9d108391e564dd88862c620639ee764a7339cd74/src/cc/payments.cpp#L275 code (started from this line) had an issues when running on Windows platform. Let's look closer what happens. For better understanding we will try to compile following simple code on Linux and on Windows with gcc/g++:

```#include <stdint.h>
#include <stdio.h>
#include <gmp.h>

int main() {

    mpz_t mpz_a; int64_t a;
    int64_t b = 71000000000;
    mpz_init(mpz_a);
    printf("mpz_a->_mp_size = %d\n",mpz_a->_mp_size);
    mpz_set_si(mpz_a,b);
    printf("mpz_a->_mp_size = %d\n",mpz_a->_mp_size);
    a = mpz_get_si(mpz_a);
    
    #if defined(_WINDOWS) || defined(_WIN32)
    printf("a=%lli",a);
    #else
    printf("a=%li",a);
    #endif
    
    return 0;

}
```
On Linux result will be following:
```
mpz_a->_mp_size = 0 
mpz_a->_mp_size = 1 
a=71000000000
```
And on Windows:
```
mpz_a->_mp_size = 0
mpz_a->_mp_size = -1
a=-2014444032
```
So we see difference in "sign" (`_mp_size`) and in `mpz_set_si` input arg `x` size - `sizeof(signed long int)` under Linux = 8 and `sizeof(signed long int)` under Windows = 4). The fix contains correct implementation of `mpz_get_si` and `mpz_set_si` for `int64_t` type for all platforms.

Let's check once again with patch:
```
#include <stdint.h>
#include <stdio.h>
#include <gmp.h>

#if (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
    #undef mpz_set_si
    #undef mpz_get_si
    #define GMP_LIMB_HIGHBIT ((mp_limb_t) 1 << (GMP_LIMB_BITS - 1))
    #define GMP_NEG_CAST(T,x) (-(int64_t)((T)((x) + 1) - 1))

    int64_t mpz_get_si (const mpz_t u) 
        {
        mp_size_t us = u->_mp_size;
        if (us > 0)
            return (int64_t) (u->_mp_d[0] & ~GMP_LIMB_HIGHBIT);
        else if (us < 0)
            return (int64_t) (- u->_mp_d[0] | GMP_LIMB_HIGHBIT);
        else
            return 0;
    }

    void mpz_set_si (mpz_t r, int64_t x)
    {
        if (x >= 0)
            mpz_set_ui (r, x);
        else /* (x < 0) */
        {
            r->_mp_size = -1;
            r->_mp_d[0] = GMP_NEG_CAST (uint64_t, x);
        }
    }
#endif

int main() {

    mpz_t mpz_a; int64_t a;
    int64_t b = 71000000000;
    mpz_init(mpz_a);
    printf("mpz_a->_mp_size = %d\n",mpz_a->_mp_size);
    mpz_set_si(mpz_a,b);
    printf("mpz_a->_mp_size = %d\n",mpz_a->_mp_size);
    printf("mpz_a->_mp_d[0] = %d\n",mpz_a->_mp_d[0]);
    
    a = mpz_get_si(mpz_a);
    
    #if defined(_WINDOWS) || defined(_WIN32)
    printf("a=%lli",a);
    #else
    printf("a=%li",a);
    #endif
    
    return 0;

}
```
Results:
Linux:
```
mpz_a->_mp_size = 0          
mpz_a->_mp_size = 1          
mpz_a->_mp_d[0] = -2014444032
a=71000000000
```
Windows:
```
mpz_a->_mp_size = 0
mpz_a->_mp_size = 1
mpz_a->_mp_d[0] = -2014444032
a=71000000000
```

**p.s.** May be exists more elegant solution to fix this, but patch in this PR is work.