### PR TITLE
Reverting binary path var

### DIFF
--- a/src/assetchains
+++ b/src/assetchains
@@ -5,6 +5,7 @@ set -eo pipefail
 source pubkey.txt
 overide_args="$@"
 seed_ip=`getent hosts zero.kolo.supernet.org | awk '{ print $1 }'`
+komodo_binary='./komodod'
 
 if [ -z "$delay" ]; then delay=20; fi
 
@@ -14,6 +15,6 @@ if [ -z "$delay" ]; then delay=20; fi
       gen=" -gen -genproclimit=1"
   fi
 
-  ./komodod $gen $args $overide_args -pubkey=$pubkey -addnode=$seed_ip &
+  $komodo_binary $gen $args $overide_args -pubkey=$pubkey -addnode=$seed_ip &
   sleep $delay
 done

--- a/src/assetchains_stop
+++ b/src/assetchains_stop
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
+komodo_cli='./komodo-cli'
 
 ./listassetchains | while read chain; do
-  ./komodo-cli --ac_name=$chain stop
+  $komodo_cli --ac_name=$chain stop
 done
+

--- a/src/fiat-cli
+++ b/src/fiat-cli
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 args="$@"
+komodo_cli='./komodo-cli'
 
 ./listassetchains | while read chain; do
   echo $chain
-  ./komodo-cli --ac_name=$chain $args
+  $komodo_cli --ac_name=$chain $args
 done


### PR DESCRIPTION
Reverting @lukechilds commit removing binary path.
It is used whenever binary path not matches `./komodo-cli` in a same directory