### PR TITLE
CC fixes for nSPV and others (#30)

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -91,7 +91,7 @@ void WaitForShutdown(boost::thread_group* threadGroup)
         //fprintf(stderr,"call passport iteration\n");
         if ( ASSETCHAINS_SYMBOL[0] == 0 )
         {
-            if ( KOMODO_NSPV <= 0 )
+            if ( KOMODO_NSPV_FULLNODE )
                 komodo_passport_iteration();
             for (i=0; i<10; i++)
             {

--- a/src/cc/CCinclude.h
+++ b/src/cc/CCinclude.h
@@ -56,7 +56,7 @@ one other technical note is that komodod has the insight-explorer extensions bui
 
 #define CC_BURNPUBKEY "02deaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead"
 #define CC_MAXVINS 1024
-#define CC_REQUIREMENTS_MSG (KOMODO_NSPV!=0?"to use CC contracts you need to nspv_login first\n":"to use CC contracts, you need to launch daemon with valid -pubkey= for an address in your wallet\n")
+#define CC_REQUIREMENTS_MSG (KOMODO_NSPV_SUPERLITE?"to use CC contracts you need to nspv_login first\n":"to use CC contracts, you need to launch daemon with valid -pubkey= for an address in your wallet\n")
 
 #define SMALLVAL 0.000000000000001
 #define SATOSHIDEN ((uint64_t)100000000L)
@@ -292,6 +292,7 @@ extern std::vector<CPubKey> NULL_pubkeys;
 std::string FinalizeCCTx(uint64_t skipmask,struct CCcontract_info *cp,CMutableTransaction &mtx,CPubKey mypk,uint64_t txfee,CScript opret,std::vector<CPubKey> pubkeys = NULL_pubkeys);
 void SetCCunspents(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs,char *coinaddr,bool CCflag = true);
 void SetCCtxids(std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,char *coinaddr,bool CCflag = true);
+void SetCCtxids_NSPV(std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,char *coinaddr,bool ccflag, uint8_t evalcode, uint256 filtertxid);
 int64_t NSPV_AddNormalinputs(CMutableTransaction &mtx,CPubKey mypk,int64_t total,int32_t maxinputs,struct NSPV_CCmtxinfo *ptr);
 int64_t AddNormalinputs(CMutableTransaction &mtx,CPubKey mypk,int64_t total,int32_t maxinputs);
 int64_t AddNormalinputs2(CMutableTransaction &mtx,int64_t total,int32_t maxinputs);

--- a/src/cc/CCtokens.cpp
+++ b/src/cc/CCtokens.cpp
@@ -957,7 +957,7 @@ UniValue TokenInfo(uint256 tokenid)
 		result.push_back(Pair("error", "cant find tokenid"));
 		return(result);
 	}
-    if ( KOMODO_NSPV <= 0 && hashBlock.IsNull()) {
+    if ( KOMODO_NSPV_FULLNODE && hashBlock.IsNull()) {
         result.push_back(Pair("result", "error"));
         result.push_back(Pair("error", "the transaction is still in mempool"));
         return(result);

--- a/src/cc/CCtx.cpp
+++ b/src/cc/CCtx.cpp
@@ -162,7 +162,7 @@ std::string FinalizeCCTx(uint64_t CCmask,struct CCcontract_info *cp,CMutableTran
             utxovout = mtx.vin[i].prevout.n;
             if ( vintx.vout[utxovout].scriptPubKey.IsPayToCryptoCondition() == 0 )
             {
-                if ( KOMODO_NSPV <= 0 )
+                if ( KOMODO_NSPV_FULLNODE )
                 {
                     if ( SignTx(mtx,i,vintx.vout[utxovout].nValue,vintx.vout[utxovout].scriptPubKey) == 0 )
                         fprintf(stderr,"signing error for vini.%d of %llx\n",i,(long long)vinimask);
@@ -340,11 +340,12 @@ std::string FinalizeCCTx(uint64_t CCmask,struct CCcontract_info *cp,CMutableTran
 
 void NSPV_CCunspents(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs,char *coinaddr,bool ccflag);
 void NSPV_CCtxids(std::vector<std::pair<CAddressIndexKey, CAmount> > &txids,char *coinaddr,bool ccflag);
+void NSPV_CCtxids(std::vector<std::pair<CAddressIndexKey, CAmount> > &txids,char *coinaddr,bool ccflag,uint8_t evalcode,uint256 filtertxid);
 
 void SetCCunspents(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs,char *coinaddr,bool ccflag)
 {
     int32_t type=0,i,n; char *ptr; std::string addrstr; uint160 hashBytes; std::vector<std::pair<uint160, int> > addresses;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         NSPV_CCunspents(unspentOutputs,coinaddr,ccflag);
         return;
@@ -368,7 +369,7 @@ void SetCCunspents(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValu
 void SetCCtxids(std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,char *coinaddr,bool ccflag)
 {
     int32_t type=0,i,n; char *ptr; std::string addrstr; uint160 hashBytes; std::vector<std::pair<uint160, int> > addresses;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         NSPV_CCtxids(addressIndex,coinaddr,ccflag);
         return;
@@ -387,6 +388,16 @@ void SetCCtxids(std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex
         if ( GetAddressIndex((*it).first, (*it).second, addressIndex) == 0 )
             return;
     }
+}
+
+void SetCCtxids_NSPV(std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,char *coinaddr,bool ccflag, uint8_t evalcode, uint256 filtertxid)
+{
+    if ( KOMODO_NSPV_SUPERLITE )
+    {
+        NSPV_CCtxids(addressIndex,coinaddr,ccflag,evalcode,filtertxid);
+        return;
+    }
+    else SetCCtxids(addressIndex,coinaddr,ccflag); 
 }
 
 int64_t CCutxovalue(char *coinaddr,uint256 utxotxid,int32_t utxovout,int32_t CCflag)
@@ -555,7 +566,7 @@ int32_t CC_vinselect(int32_t *aboveip,int64_t *abovep,int32_t *belowip,int64_t *
 int64_t AddNormalinputs(CMutableTransaction &mtx,CPubKey mypk,int64_t total,int32_t maxinputs)
 {
     int32_t abovei,belowi,ind,vout,i,n = 0; int64_t sum,threshold,above,below; int64_t remains,nValue,totalinputs = 0; uint256 txid,hashBlock; std::vector<COutput> vecOutputs; CTransaction tx; struct CC_utxo *utxos,*up;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         return(NSPV_AddNormalinputs(mtx,mypk,total,maxinputs,&NSPV_U));
 #ifdef ENABLE_WALLET
     assert(pwalletMain != NULL);
@@ -652,7 +663,7 @@ int64_t AddNormalinputs2(CMutableTransaction &mtx,int64_t total,int32_t maxinput
 {
     int32_t abovei,belowi,ind,vout,i,n = 0; int64_t sum,threshold,above,below; int64_t remains,nValue,totalinputs = 0; char coinaddr[64]; uint256 txid,hashBlock; CTransaction tx; struct CC_utxo *utxos,*up;
     std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > unspentOutputs;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         return(NSPV_AddNormalinputs(mtx,pubkey2pk(Mypubkey()),total,maxinputs,&NSPV_U));
     utxos = (struct CC_utxo *)calloc(CC_MAXVINS,sizeof(*utxos));
     if ( maxinputs > CC_MAXVINS )

--- a/src/cc/CCutils.cpp
+++ b/src/cc/CCutils.cpp
@@ -450,7 +450,7 @@ extern uint32_t NSPV_logintime;
 bool Myprivkey(uint8_t myprivkey[])
 {
     char coinaddr[64],checkaddr[64]; std::string strAddress; char *dest; int32_t i,n; CBitcoinAddress address; CKeyID keyID; CKey vchSecret; uint8_t buf33[33];
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         if ( NSPV_logintime == 0 || time(NULL) > NSPV_logintime+NSPV_AUTOLOGOUT )
         {
@@ -590,7 +590,7 @@ int32_t NSPV_coinaddr_inmempool(char const *logcategory,char *coinaddr,uint8_t C
 int32_t myIs_coinaddr_inmempoolvout(char const *logcategory,char *coinaddr)
 {
     int32_t i,n; char destaddr[64];
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         return(NSPV_coinaddr_inmempool(logcategory,coinaddr,1));
     BOOST_FOREACH(const CTxMemPoolEntry &e,mempool.mapTx)
     {
@@ -619,7 +619,7 @@ int32_t myGet_mempool_txs(std::vector<CTransaction> &txs,uint8_t evalcode,uint8_
 {
     int i=0;
 
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         CTransaction tx; uint256 hashBlock;
 
@@ -673,7 +673,7 @@ bool komodo_txnotarizedconfirmed(uint256 txid)
     CBlockIndex *pindex;    
     char symbol[KOMODO_ASSETCHAIN_MAXLEN],dest[KOMODO_ASSETCHAIN_MAXLEN]; struct komodo_state *sp;
 
-    if (KOMODO_NSPV!=0)
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         if ( NSPV_myGetTransaction(txid,tx,hashBlock,txheight,currentheight) == 0 )
         {

--- a/src/cc/channels.cpp
+++ b/src/cc/channels.cpp
@@ -846,7 +846,7 @@ UniValue ChannelsInfo(uint256 channeltxid)
             result.push_back(Pair("Amount (satoshi)",i64tostr(param1*param2)));
         }
         GetCCaddress(cp,CCaddr,mypk);
-        SetCCtxids(addressIndex,CCaddr,true);                      
+        SetCCtxids_NSPV(addressIndex,CCaddr,true,EVAL_CHANNELS,opentxid);                      
         for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++)
         {
             if (myGetTransaction(it->first.txhash,tx,hashBlock) != 0 && (numvouts= tx.vout.size()) > 0 && it->second==CC_MARKER_VALUE &&

--- a/src/cc/oracles.cpp
+++ b/src/cc/oracles.cpp
@@ -641,6 +641,7 @@ bool OraclesDataValidate(struct CCcontract_info *cp,Eval* eval,const CTransactio
 
 int32_t GetLatestTimestamp(int32_t height)
 {
+    if ( KOMODO_NSPV_SUPERLITE ) return (NSPV_blocktime(height));
     return(komodo_heightstamp(height));
 }
 
@@ -793,7 +794,7 @@ int64_t LifetimeOraclesFunds(struct CCcontract_info *cp,uint256 oracletxid,CPubK
     char coinaddr[64]; CPubKey pk; int64_t total=0,num; uint256 txid,hashBlock,subtxid; CTransaction subtx;
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
     GetCCaddress(cp,coinaddr,publisher);
-    SetCCtxids(addressIndex,coinaddr,true);
+    SetCCtxids_NSPV(addressIndex,coinaddr,true,EVAL_ORACLES,oracletxid);
     //fprintf(stderr,"scan lifetime of %s\n",coinaddr);
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++)
     {

--- a/src/cc/pegs.cpp
+++ b/src/cc/pegs.cpp
@@ -1234,7 +1234,7 @@ UniValue PegsAccountHistory(uint256 pegstxid)
     mypk = pubkey2pk(Mypubkey());
     pegspk = GetUnspendable(cp,0);
     GetCCaddress1of2(cp,coinaddr,mypk,pegspk);
-    SetCCtxids(txids,coinaddr,true);
+    SetCCtxids_NSPV(txids,coinaddr,true,EVAL_PEGS,pegstxid);
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=txids.begin(); it!=txids.end(); it++)
     {
         txid = it->first.txhash;

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -21,6 +21,14 @@
 extern int32_t KOMODO_NSPV;
 #define NSPV_BRANCHID 0x76b809bb
 
+#ifndef KOMODO_NSPV_FULLNODE
+#define KOMODO_NSPV_FULLNODE (KOMODO_NSPV <= 0)
+#endif // !KOMODO_NSPV_FULLNODE
+
+#ifndef KOMODO_NSPV_SUPERLITE
+#define KOMODO_NSPV_SUPERLITE (KOMODO_NSPV > 0)
+#endif // !KOMODO_NSPV_SUPERLITE
+
 /**
  * General information about each network upgrade.
  * Ordered by Consensus::UpgradeIndex.
@@ -101,7 +109,7 @@ int CurrentEpoch(int nHeight, const Consensus::Params& params) {
 
 uint32_t CurrentEpochBranchId(int nHeight, const Consensus::Params& params)
 {
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         return(NSPV_BRANCHID);
     return NetworkUpgradeInfo[CurrentEpoch(nHeight, params)].nBranchId;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1066,7 +1066,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     RegisterAllCoreRPCCommands(tableRPC);
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         fDisableWallet = true;
         nLocalServices = 0;
@@ -1147,7 +1147,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op
 
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         if (GetBoolArg("-peerbloomfilters", true))
             nLocalServices |= NODE_BLOOM;
@@ -1306,7 +1306,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     libsnark::inhibit_profiling_info = true;
     libsnark::inhibit_profiling_counters = true;
 
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         // Initialize Zcash circuit parameters
         ZC_LoadParams(chainparams);
@@ -1487,7 +1487,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 #endif
 
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         std::vector<boost::filesystem::path> vImportFiles;
         threadGroup.create_thread(boost::bind(&ThreadImport, vImportFiles));

--- a/src/komodo.h
+++ b/src/komodo.h
@@ -67,9 +67,14 @@ void komodo_currentheight_set(int32_t height)
         sp->CURRENT_HEIGHT = height;
 }
 
+extern struct NSPV_inforesp NSPV_inforesult;
 int32_t komodo_currentheight()
 {
     char symbol[KOMODO_ASSETCHAIN_MAXLEN],dest[KOMODO_ASSETCHAIN_MAXLEN]; struct komodo_state *sp;
+    if ( KOMODO_NSPV_SUPERLITE )
+    {
+        return (NSPV_inforesult.height);
+    }
     if ( (sp= komodo_stateptr(symbol,dest)) != 0 )
         return(sp->CURRENT_HEIGHT);
     else return(0);

--- a/src/komodo_defs.h
+++ b/src/komodo_defs.h
@@ -345,4 +345,11 @@ arith_uint256 komodo_adaptivepow_target(int32_t height,arith_uint256 bnTarget,ui
 
 uint256 Parseuint256(const char *hexstr);
 
+#ifndef KOMODO_NSPV_FULLNODE
+#define KOMODO_NSPV_FULLNODE (KOMODO_NSPV <= 0)
+#endif // !KOMODO_NSPV_FULLNODE
+#ifndef KOMODO_NSPV_SUPERLITE
+#define KOMODO_NSPV_SUPERLITE (KOMODO_NSPV > 0)
+#endif // !KOMODO_NSPV_SUPERLITE
+
 #endif

--- a/src/komodo_nSPV_superlite.h
+++ b/src/komodo_nSPV_superlite.h
@@ -214,7 +214,7 @@ void komodo_nSPVresp(CNode *pfrom,std::vector<uint8_t> response) // received a r
 CNode *NSPV_req(CNode *pnode,uint8_t *msg,int32_t len,uint64_t mask,int32_t ind)
 {
     int32_t n,flag = 0; CNode *pnodes[64]; uint32_t timestamp = (uint32_t)time(NULL);
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         return(0);
     if ( pnode == 0 )
     {
@@ -243,7 +243,7 @@ CNode *NSPV_req(CNode *pnode,uint8_t *msg,int32_t len,uint64_t mask,int32_t ind)
         std::vector<uint8_t> request;
         request.resize(len);
         memcpy(&request[0],msg,len);
-        if ( (0) && KOMODO_NSPV > 0 )
+        if ( (0) && KOMODO_NSPV_SUPERLITE )
             fprintf(stderr,"pushmessage [%d] len.%d\n",msg[0],len);
         pnode->PushMessage("getnSPV",request);
         pnode->prevtimes[ind] = timestamp;
@@ -279,7 +279,7 @@ void komodo_nSPV(CNode *pto) // polling loop from SendMessages
         return;
     if ( pto->prevtimes[NSPV_INFO>>1] > timestamp )
         pto->prevtimes[NSPV_INFO>>1] = 0;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         if ( timestamp > NSPV_lastinfo + ASSETCHAINS_BLOCKTIME/2 && timestamp > pto->prevtimes[NSPV_INFO>>1] + 2*ASSETCHAINS_BLOCKTIME/3 )
         {
@@ -355,7 +355,7 @@ UniValue NSPV_getinfo_json(struct NSPV_inforesp *ptr)
 {
     UniValue result(UniValue::VOBJ); int32_t expiration; uint32_t timestamp = (uint32_t)time(NULL);
     result.push_back(Pair("result","success"));
-    result.push_back(Pair("nSPV",KOMODO_NSPV!=0?"superlite":"fullnode"));
+    result.push_back(Pair("nSPV",KOMODO_NSPV==-1?"disabled":(KOMODO_NSPV_SUPERLITE?"superlite":"fullnode")));
     if ( NSPV_address.size() != 0 )
     {
         result.push_back(Pair("address",NSPV_address));
@@ -537,7 +537,7 @@ UniValue NSPV_login(char *wifstr)
     result.push_back(Pair("address",NSPV_address));
     result.push_back(Pair("pubkey",HexStr(pubkey)));
     strcpy(NSPV_pubkeystr,HexStr(pubkey).c_str());
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         decode_hex(NOTARY_PUBKEY33,33,NSPV_pubkeystr);
     result.push_back(Pair("wifprefix",(int64_t)data[0]));
     result.push_back(Pair("compressed",(int64_t)(data[len-5] == 1)));
@@ -621,7 +621,7 @@ UniValue NSPV_addressutxos(char *coinaddr,int32_t CCflag,int32_t skipcount,int32
     return(result);
 }
 
-UniValue NSPV_addresstxids(char *coinaddr,int32_t CCflag,int32_t skipcount,int32_t filter)
+UniValue NSPV_addresstxids(char *coinaddr,int32_t CCflag,int32_t skipcount,int32_t filter, uint256 filtertxid)
 {
     UniValue result(UniValue::VOBJ); uint8_t msg[512]; int32_t i,iter,slen,len = 0;
     if ( NSPV_txidsresult.nodeheight >= NSPV_inforesult.height && strcmp(coinaddr,NSPV_txidsresult.coinaddr) == 0 && CCflag == NSPV_txidsresult.CCflag && skipcount == NSPV_txidsresult.skipcount )
@@ -642,6 +642,11 @@ UniValue NSPV_addresstxids(char *coinaddr,int32_t CCflag,int32_t skipcount,int32
     msg[len++] = (CCflag != 0);
     len += iguana_rwnum(1,&msg[len],sizeof(skipcount),&skipcount);
     len += iguana_rwnum(1,&msg[len],sizeof(filter),&filter);
+    if (filtertxid!=zeroid)
+    {
+        NSPV_txidsresult.txids = (struct NSPV_txidresp *)malloc(sizeof(NSPV_txidsresult.txids));
+        NSPV_txidsresult.txids[0].txid=filtertxid;
+    }
     //fprintf(stderr,"skipcount.%d\n",skipcount);
     for (iter=0; iter<3; iter++)
     if ( NSPV_req(0,msg,len,NODE_ADDRINDEX,msg[0]>>1) != 0 )

--- a/src/komodo_nSPV_wallet.h
+++ b/src/komodo_nSPV_wallet.h
@@ -452,12 +452,12 @@ int64_t NSPV_AddNormalinputs(CMutableTransaction &mtx,CPubKey mypk,int64_t total
         mtx.nVersionGroupId = SAPLING_VERSION_GROUP_ID;
         mtx.nVersion = SAPLING_TX_VERSION;
         Getscriptaddress(coinaddr,CScript() << ParseHex(HexStr(mypk)) << OP_CHECKSIG);
-        if ( strcmp(ptr->U.coinaddr,coinaddr) != 0 )
-        {
+        // if ( strcmp(ptr->U.coinaddr,coinaddr) != 0 )
+        // {
             NSPV_addressutxos(coinaddr,CCflag,0,0);
             NSPV_utxosresp_purge(&ptr->U);
             NSPV_utxosresp_copy(&ptr->U,&NSPV_utxosresult);
-        }
+        // }
         fprintf(stderr,"%s numutxos.%d\n",ptr->U.coinaddr,ptr->U.numutxos);
         memset(ptr->used,0,sizeof(ptr->used));
         return(NSPV_addinputs(ptr->used,mtx,total,maxinputs,ptr->U.utxos,ptr->U.numutxos));
@@ -522,7 +522,14 @@ void NSPV_CCunspents(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentVa
 void NSPV_CCtxids(std::vector<std::pair<CAddressIndexKey, CAmount> > &txids,char *coinaddr,bool ccflag)
 {
     int32_t filter = 0;
-    NSPV_addresstxids(coinaddr,ccflag,0,filter);
+    NSPV_addresstxids(coinaddr,ccflag,0,filter,zeroid);
+    NSPV_txids2CCtxids(&NSPV_txidsresult,txids);
+}
+
+void NSPV_CCtxids(std::vector<std::pair<CAddressIndexKey, CAmount> > &txids,char *coinaddr,bool ccflag, uint8_t evalcode,uint256 filtertxid)
+{
+    int32_t filter = evalcode;
+    NSPV_addresstxids(coinaddr,ccflag,0,filter,filtertxid);
     NSPV_txids2CCtxids(&NSPV_txidsresult,txids);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2227,7 +2227,7 @@ bool myAddtomempool(CTransaction &tx, CValidationState *pstate, bool fSkipExpiry
 bool myGetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock)
 {
     memset(&hashBlock,0,sizeof(hashBlock));
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         int64_t rewardsum = 0; int32_t i,retval,txheight,currentheight,height=0,vout = 0;
         for (i=0; i<NSPV_U.U.numutxos; i++)
@@ -2281,7 +2281,7 @@ bool myGetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlo
 bool NSPV_myGetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, int32_t &txheight, int32_t &currentheight)
 {
     memset(&hashBlock,0,sizeof(hashBlock));
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         int64_t rewardsum = 0; int32_t i,retval,height=0,vout = 0;
         for (i=0; i<NSPV_U.U.numutxos; i++)
@@ -3427,7 +3427,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 {
     CDiskBlockPos blockPos;
     const CChainParams& chainparams = Params();
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         return(true);
     if ( KOMODO_STOPAT != 0 && pindex->GetHeight() > KOMODO_STOPAT )
         return(false);
@@ -4011,7 +4011,7 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode) {
 
 void FlushStateToDisk() {
     CValidationState state;
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         FlushStateToDisk(state, FLUSH_STATE_ALWAYS);
 }
 
@@ -4162,7 +4162,7 @@ bool static DisconnectTip(CValidationState &state, bool fBare = false) {
         if ((i == (block.vtx.size() - 1)) && (ASSETCHAINS_STAKED != 0 && (komodo_isPoS((CBlock *)&block,pindexDelete->GetHeight(),true) != 0)))
         {
 #ifdef ENABLE_WALLET
-            if ( !GetBoolArg("-disablewallet", false) && KOMODO_NSPV <= 0 )
+            if ( !GetBoolArg("-disablewallet", false) && KOMODO_NSPV_FULLNODE )
                 pwalletMain->EraseFromWallet(tx.GetHash());
 #endif
         }
@@ -4267,7 +4267,7 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
     // Get the current commitment tree
     SproutMerkleTree oldSproutTree;
     SaplingMerkleTree oldSaplingTree;
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         assert(pcoinsTip->GetSproutAnchorAt(pcoinsTip->GetBestAnchor(SPROUT), oldSproutTree));
         assert(pcoinsTip->GetSaplingAnchorAt(pcoinsTip->GetBestAnchor(SAPLING), oldSaplingTree));
@@ -4296,13 +4296,13 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
         mapBlockSource.erase(pindexNew->GetBlockHash());
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;
         LogPrint("bench", "  - Connect total: %.2fms [%.2fs]\n", (nTime3 - nTime2) * 0.001, nTimeConnectTotal * 0.000001);
-        if ( KOMODO_NSPV <= 0 )
+        if ( KOMODO_NSPV_FULLNODE )
             assert(view.Flush());
     }
     int64_t nTime4 = GetTimeMicros(); nTimeFlush += nTime4 - nTime3;
     LogPrint("bench", "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);
     // Write the chain state to disk, if necessary.
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
             return false;
@@ -4318,7 +4318,7 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
 
     // Update chainActive & related variables.
     UpdateTip(pindexNew);
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         // Tell wallet about transactions that went from mempool
         // to conflicted:
@@ -4346,7 +4346,7 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
         komodo_broadcast(pblock,8);
     else if ( ASSETCHAINS_SYMBOL[0] != 0 )
         komodo_broadcast(pblock,4);*/
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         if ( ASSETCHAINS_CBOPRET != 0 )
             komodo_pricesupdate(pindexNew->GetHeight(),pblock);
@@ -6568,7 +6568,7 @@ bool InitBlockIndex() {
             if (!ActivateBestChain(true, state, &block))
                 return error("LoadBlockIndex(): genesis block cannot be activated");
             // Force a chainstate write so that when we VerifyDB in a moment, it doesn't check stale data
-            if ( KOMODO_NSPV <= 0 )
+            if ( KOMODO_NSPV_FULLNODE )
                 return FlushStateToDisk(state, FLUSH_STATE_ALWAYS);
             else return(true);
         } catch (const std::runtime_error& e) {
@@ -7128,7 +7128,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     const CChainParams& chainparams = Params();
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
-    //if ( KOMODO_NSPV > 0 )
+    //if ( KOMODO_NSPV_SUPERLITE )
     //if ( strCommand != "version" && strCommand != "verack" )
     //    fprintf(stderr, "recv: %s (%u bytes) peer=%d\n", SanitizeString(strCommand).c_str(), (int32_t)vRecv.size(), (int32_t)pfrom->GetId());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
@@ -7303,7 +7303,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     {
         pfrom->SetRecvVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
 
-        if ( KOMODO_NSPV > 0 )
+        if ( KOMODO_NSPV_SUPERLITE )
         {
             if ( (pfrom->nServices & NODE_NSPV) == 0 )
             {
@@ -7513,7 +7513,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     }
     else if (strCommand == "nSPV")
     {
-        if ( KOMODO_NSPV > 0 )
+        if ( KOMODO_NSPV_SUPERLITE )
         {
             std::vector<uint8_t> payload;
             vRecv >> payload;
@@ -7521,7 +7521,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
         return(true);
     }
-    else if ( KOMODO_NSPV > 0 )
+    else if ( KOMODO_NSPV_SUPERLITE )
         return(true);
     else if (strCommand == "inv")
     {
@@ -8311,7 +8311,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             }
             state.fShouldBan = false;
         }
-        if ( KOMODO_NSPV > 0 )
+        if ( KOMODO_NSPV_SUPERLITE )
         {
             komodo_nSPV(pto);
             return(true);
@@ -8522,7 +8522,7 @@ extern "C" const char* getDataDir()
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight)
 {
     CMutableTransaction mtx;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         mtx.fOverwintered = true;
         mtx.nExpiryHeight = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -445,6 +445,13 @@ void CNode::CloseSocketDisconnect()
 }
 
 extern int32_t KOMODO_NSPV;
+#ifndef KOMODO_NSPV_FULLNODE
+#define KOMODO_NSPV_FULLNODE (KOMODO_NSPV <= 0)
+#endif // !KOMODO_NSPV_FULLNODE
+
+#ifndef KOMODO_NSPV_SUPERLITE
+#define KOMODO_NSPV_SUPERLITE (KOMODO_NSPV > 0)
+#endif // !KOMODO_NSPV_SUPERLITE
 
 void CNode::PushVersion()
 {
@@ -1843,7 +1850,7 @@ bool StopNode()
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
             semOutbound->post();
 
-    if (KOMODO_NSPV <= 0 && fAddressesInitialized)
+    if (KOMODO_NSPV_FULLNODE && fAddressesInitialized)
     {
         DumpAddresses();
         fAddressesInitialized = false;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -396,7 +396,7 @@ bool NSPV_inmempool(uint256 txid);
 bool myIsutxo_spentinmempool(uint256 &spenttxid,int32_t &spentvini,uint256 txid,int32_t vout)
 {
     int32_t vini = 0;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         return(NSPV_spentinmempool(spenttxid,spentvini,txid,vout));
     BOOST_FOREACH(const CTxMemPoolEntry &e,mempool.mapTx)
     {
@@ -420,7 +420,7 @@ bool myIsutxo_spentinmempool(uint256 &spenttxid,int32_t &spentvini,uint256 txid,
 
 bool mytxid_inmempool(uint256 txid)
 {
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -243,7 +243,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("prevMoMheight", prevMoMheight));
     obj.push_back(Pair("notarizedhash", notarized_hash.ToString()));
     obj.push_back(Pair("notarizedtxid", notarized_desttxid.ToString()));
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         txid_height = notarizedtxid_height(ASSETCHAINS_SYMBOL[0] != 0 ? (char *)"KMD" : (char *)"BTC",(char *)notarized_desttxid.ToString().c_str(),&kmdnotarized_height);
         if ( txid_height > 0 )

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -374,7 +374,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         const CTxOut& txout = tx.vout[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
-        if ( KOMODO_NSPV <= 0 && ASSETCHAINS_SYMBOL[0] == 0 && tx.nLockTime >= 500000000 && (tipindex= chainActive.LastTip()) != 0 )
+        if ( KOMODO_NSPV_FULLNODE && ASSETCHAINS_SYMBOL[0] == 0 && tx.nLockTime >= 500000000 && (tipindex= chainActive.LastTip()) != 0 )
         {
             int64_t interest; int32_t txheight; uint32_t locktime;
             interest = komodo_accrued_interest(&txheight,&locktime,tx.GetHash(),i,0,txout.nValue,(int32_t)tipindex->GetHeight());
@@ -1366,7 +1366,7 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
     bool fOverrideFees = false;
     if (params.size() > 1)
         fOverrideFees = params[1].get_bool();
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
     {
         CCoinsViewCache &view = *pcoinsTip;
         const CCoins* existingCoins = view.AccessCoins(hashTx);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -37,6 +37,13 @@ typedef vector<unsigned char> valtype;
 extern uint8_t ASSETCHAINS_TXPOW;
 extern char NSPV_wifstr[],NSPV_pubkeystr[];
 extern int32_t KOMODO_NSPV;
+#ifndef KOMODO_NSPV_FULLNODE
+#define KOMODO_NSPV_FULLNODE (KOMODO_NSPV <= 0)
+#endif // !KOMODO_NSPV_FULLNODE
+#ifndef KOMODO_NSPV_SUPERLITE
+#define KOMODO_NSPV_SUPERLITE (KOMODO_NSPV > 0)
+#endif // !KOMODO_NSPV_SUPERLITE
+
 uint256 SIG_TXHASH;
 
 TransactionSignatureCreator::TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn) : BaseSignatureCreator(keystoreIn), txTo(txToIn), nIn(nInIn), nHashType(nHashTypeIn), amount(amountIn), checker(txTo, nIn, amountIn) {}
@@ -53,7 +60,7 @@ bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, 
         }
     }
     SIG_TXHASH = hash;
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         key = DecodeSecret(NSPV_wifstr);
     else if (pprivKey)
         key = *pprivKey;
@@ -74,7 +81,7 @@ bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, 
             return false;
         }
         vchSig = CCSigVec(cc);
-        if ( KOMODO_NSPV > 0 )
+        if ( KOMODO_NSPV_SUPERLITE )
             memset((uint8_t *)key.begin(),0,32);
         return true;
     }
@@ -100,7 +107,7 @@ bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, 
     }
     
     vchSig.push_back((unsigned char)nHashType);
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
         memset((uint8_t *)key.begin(),0,32);
     return true;
 }
@@ -381,7 +388,7 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
             }
             else
             {
-                if ( KOMODO_NSPV <= 0 )
+                if ( KOMODO_NSPV_FULLNODE )
                 {
                     CPubKey vch;
                     creator.KeyStore().GetPubKey(keyID, vch);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -973,10 +973,17 @@ UniValue z_exportviewingkey(const UniValue& params, bool fHelp)
 }
 
 extern int32_t KOMODO_NSPV;
+#ifndef KOMODO_NSPV_FULLNODE
+#define KOMODO_NSPV_FULLNODE (KOMODO_NSPV <= 0)
+#endif // !KOMODO_NSPV_FULLNODE
+#ifndef KOMODO_NSPV_SUPERLITE
+#define KOMODO_NSPV_SUPERLITE (KOMODO_NSPV > 0)
+#endif // !KOMODO_NSPV_SUPERLITE
+uint256 zeroid;
 UniValue NSPV_getinfo_req(int32_t reqht);
 UniValue NSPV_login(char *wifstr);
 UniValue NSPV_logout();
-UniValue NSPV_addresstxids(char *coinaddr,int32_t CCflag,int32_t skipcount,int32_t filter);
+UniValue NSPV_addresstxids(char *coinaddr,int32_t CCflag,int32_t skipcount,int32_t filter, uint256 filtertxid);
 UniValue NSPV_addressutxos(char *coinaddr,int32_t CCflag,int32_t skipcount,int32_t filter);
 UniValue NSPV_mempooltxids(char *coinaddr,int32_t CCflag,uint8_t funcid,uint256 txid,int32_t vout);
 UniValue NSPV_broadcast(char *hex);
@@ -993,7 +1000,7 @@ UniValue nspv_getinfo(const UniValue& params, bool fHelp)
     int32_t reqht = 0;
     if ( fHelp || params.size() > 1 )
         throw runtime_error("nspv_getinfo [hdrheight]\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     if ( params.size() == 1 )
         reqht = atoi((char *)params[0].get_str().c_str());
@@ -1004,7 +1011,7 @@ UniValue nspv_logout(const UniValue& params, bool fHelp)
 {
     if ( fHelp || params.size() != 0 )
         throw runtime_error("nspv_logout\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     return(NSPV_logout());
 }
@@ -1013,7 +1020,7 @@ UniValue nspv_login(const UniValue& params, bool fHelp)
 {
     if ( fHelp || params.size() != 1 )
         throw runtime_error("nspv_login wif\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     return(NSPV_login((char *)params[0].get_str().c_str()));
 }
@@ -1023,7 +1030,7 @@ UniValue nspv_listunspent(const UniValue& params, bool fHelp)
     int32_t skipcount = 0,CCflag = 0;
     if ( fHelp || params.size() > 3 )
         throw runtime_error("nspv_listunspent [address [isCC [skipcount]]]\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     if ( params.size() == 0 )
     {
@@ -1048,7 +1055,7 @@ UniValue nspv_mempool(const UniValue& params, bool fHelp)
     memset(&txid,0,sizeof(txid));
     if ( fHelp || params.size() > 5 )
         throw runtime_error("nspv_mempool func(0 all, 1 address recv, 2 txid/vout spent, 3 txid inmempool) address isCC [txid vout]]]\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     funcid = atoi((char *)params[0].get_str().c_str());
     coinaddr = (char *)params[1].get_str().c_str();
@@ -1068,12 +1075,12 @@ UniValue nspv_listtransactions(const UniValue& params, bool fHelp)
     int32_t skipcount = 0,CCflag = 0;
     if ( fHelp || params.size() > 3 )
         throw runtime_error("nspv_listtransactions [address [isCC [skipcount]]]\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     if ( params.size() == 0 )
     {
         if ( NSPV_address.size() != 0 )
-            return(NSPV_addresstxids((char *)NSPV_address.c_str(),0,0,0));
+            return(NSPV_addresstxids((char *)NSPV_address.c_str(),0,0,0,zeroid));
         else throw runtime_error("nspv_listtransactions [address [isCC [skipcount]]]\n");
     }
     if ( params.size() >= 1 )
@@ -1083,7 +1090,7 @@ UniValue nspv_listtransactions(const UniValue& params, bool fHelp)
         if ( params.size() == 3 )
             skipcount = atoi((char *)params[2].get_str().c_str());
         //fprintf(stderr,"call txids cc.%d skip.%d\n",CCflag,skipcount);
-        return(NSPV_addresstxids((char *)params[0].get_str().c_str(),CCflag,skipcount,0));
+        return(NSPV_addresstxids((char *)params[0].get_str().c_str(),CCflag,skipcount,0,zeroid));
     }
     else throw runtime_error("nspv_listtransactions [address [isCC [skipcount]]]\n");
 }
@@ -1093,7 +1100,7 @@ UniValue nspv_spentinfo(const UniValue& params, bool fHelp)
     uint256 txid; int32_t vout;
     if ( fHelp || params.size() != 2 )
         throw runtime_error("nspv_spentinfo txid vout\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     txid = Parseuint256((char *)params[0].get_str().c_str());
     vout = atoi((char *)params[1].get_str().c_str());
@@ -1105,7 +1112,7 @@ UniValue nspv_notarizations(const UniValue& params, bool fHelp)
     int32_t height;
     if ( fHelp || params.size() != 1 )
         throw runtime_error("nspv_notarizations height\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     height = atoi((char *)params[0].get_str().c_str());
     return(NSPV_notarizations(height));
@@ -1116,7 +1123,7 @@ UniValue nspv_hdrsproof(const UniValue& params, bool fHelp)
     int32_t prevheight,nextheight;
     if ( fHelp || params.size() != 2 )
         throw runtime_error("nspv_hdrsproof prevheight nextheight\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     prevheight = atoi((char *)params[0].get_str().c_str());
     nextheight = atoi((char *)params[1].get_str().c_str());
@@ -1128,7 +1135,7 @@ UniValue nspv_txproof(const UniValue& params, bool fHelp)
     uint256 txid; int32_t height;
     if ( fHelp || params.size() != 2 )
         throw runtime_error("nspv_txproof txid height\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     txid = Parseuint256((char *)params[0].get_str().c_str());
     height = atoi((char *)params[1].get_str().c_str());
@@ -1140,7 +1147,7 @@ UniValue nspv_spend(const UniValue& params, bool fHelp)
     uint64_t satoshis;
     if ( fHelp || params.size() != 2 )
         throw runtime_error("nspv_spend address amount\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     if ( NSPV_address.size() == 0 )
         throw runtime_error("to nspv_send you need an active nspv_login\n");
@@ -1155,7 +1162,7 @@ UniValue nspv_broadcast(const UniValue& params, bool fHelp)
 {
     if ( fHelp || params.size() != 1 )
         throw runtime_error("nspv_broadcast hex\n");
-    if ( KOMODO_NSPV <= 0 )
+    if ( KOMODO_NSPV_FULLNODE )
         throw runtime_error("-nSPV=1 must be set to use nspv\n");
     return(NSPV_broadcast((char *)params[0].get_str().c_str()));
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -162,7 +162,7 @@ void OS_randombytes(unsigned char *x,long xlen);
 
 UniValue getnewaddress(const UniValue& params, bool fHelp)
 {
-    if ( KOMODO_NSPV <= 0 && !EnsureWalletIsAvailable(fHelp) )
+    if ( KOMODO_NSPV_FULLNODE && !EnsureWalletIsAvailable(fHelp) )
         return NullUniValue;
 
     if (fHelp || params.size() > 1)
@@ -178,7 +178,7 @@ UniValue getnewaddress(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getnewaddress", "")
         );
 
-    if ( KOMODO_NSPV > 0 )
+    if ( KOMODO_NSPV_SUPERLITE )
     {
         UniValue result(UniValue::VOBJ); uint8_t priv32[32];
 #ifndef __WIN32
@@ -2974,7 +2974,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
 uint64_t komodo_interestsum()
 {
 #ifdef ENABLE_WALLET
-    if ( ASSETCHAINS_SYMBOL[0] == 0 && GetBoolArg("-disablewallet", false) == 0 && KOMODO_NSPV <= 0 )
+    if ( ASSETCHAINS_SYMBOL[0] == 0 && GetBoolArg("-disablewallet", false) == 0 && KOMODO_NSPV_FULLNODE )
     {
         uint64_t interest,sum = 0; int32_t txheight; uint32_t locktime;
         vector<COutput> vecOutputs;
@@ -7002,7 +7002,7 @@ UniValue faucetfund(const UniValue& params, bool fHelp)
     if ( fHelp || params.size() > 1 )
         throw runtime_error("faucetfund amount\n");
     funds = atof(params[0].get_str().c_str()) * COIN + 0.00000000499999;
-    if ( (0) && KOMODO_NSPV > 0 )
+    if ( (0) && KOMODO_NSPV_SUPERLITE )
     {
         char coinaddr[64]; struct CCcontract_info *cp,C; CTxOut v;
         cp = CCinit(&C,EVAL_FAUCET);


### PR DESCRIPTION
- Remove adding txfee inputs for gateways claim
- FULLNODE and SUPERLITE macros
- Filter SetCCtxids with txid from oprert
- Fix for nServices of fullnode
- Use SetCCtxids_nSPV for some more CCs
- Fix addnormalinputs and add checking if utxo spent in mempool