### PR TITLE
Fix Debian package metadata

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,22 +1,18 @@
-Source: VerusCoin
+Source: komodo
 Section: utils
 Priority: optional
-Maintainer: VerusCoin <team@z.cash>
-Homepage: https://veruscoin.io
+Maintainer: Komodo Platform <support@komodoplatform.com>
+Homepage: https://komodoplatform.com/
 Build-Depends: autoconf, automake, bsdmainutils, build-essential,
  git, g++-multilib, libc6-dev, libtool,
  m4, ncurses-dev, pkg-config, python,
  unzip, wget, zlib1g-dev
-Vcs-Git: https://github.com/VeruscCoin/VerusCoin.git
-Vcs-Browser: https://github.com/VerusCoin/VerusCoin
+Vcs-Git: https://github.com/jl777/komodo
+Vcs-Browser: https://github.com/jl777/komodo
 
-Package: Verus-CLI
+Package: komodo
 Architecture: amd64
 Depends: ${shlibs:Depends}
-Description: VerusCoin is a new, mineable and stakeable cryptocurrency.
-It is a live fork of Komodo that retains its Zcash lineage and improves it.
-VerusCoin will leverage the Komodo platform and dPoW notarization for enhanced security and cross-chain interoperability.
-We have added a variation of a zawy12, lwma difficulty algorithm, a new CPU-optimized hash algorithm and a new algorithm for fair proof of stake.
-We describe these changes and vision going forward in a [our Phase I white paper](http://185.25.51.16/papers/VerusPhaseI.pdf) and
-[our Vision](http://185.25.51.16/papers/VerusVision.pdf).
-
+Description: Komodo (KMD) full node. The future is multi-chain.
+ This package provides the daemon, komodod, and the CLI tool,
+ komodo-cli, to interact with the daemon.


### PR DESCRIPTION
This is mostly reverting back to a KMD version that was accidentally undone in a merge, with a few improvements.