### PR TITLE
pubkey2pk fix to use standard CPubKey::Set function with length check

### DIFF
--- a/src/cc/CCinclude.h
+++ b/src/cc/CCinclude.h
@@ -267,7 +267,7 @@ bool pubkey2addr(char *destaddr,uint8_t *pubkey33);
 char *uint256_str(char *dest,uint256 txid);
 char *pubkey33_str(char *dest,uint8_t *pubkey33);
 uint256 Parseuint256(const char *hexstr);
-CPubKey pubkey2pk(std::vector<uint8_t> pubkey);
+CPubKey pubkey2pk(std::vector<uint8_t> vpubkey);
 int64_t CCfullsupply(uint256 tokenid);
 int64_t CCtoken_balance(char *destaddr,uint256 tokenid);
 int64_t CCtoken_balance2(char *destaddr,uint256 tokenid);

--- a/src/cc/CCutilbits.cpp
+++ b/src/cc/CCutilbits.cpp
@@ -93,13 +93,9 @@ CPubKey buf2pk(uint8_t *buf33)
     return(pk);
 }
 
-CPubKey pubkey2pk(std::vector<uint8_t> pubkey)
+CPubKey pubkey2pk(std::vector<uint8_t> vpubkey)
 {
-    CPubKey pk; int32_t i,n; uint8_t *dest,*pubkey33;
-    n = pubkey.size();
-    dest = (uint8_t *)pk.begin();
-    pubkey33 = (uint8_t *)pubkey.data();
-    for (i=0; i<n; i++)
-        dest[i] = pubkey33[i];
+    CPubKey pk; 
+    pk.Set(vpubkey.begin(), vpubkey.end());
     return(pk);
 }


### PR DESCRIPTION
(the current version does not check the input data len what could lead to bad mem)