### PR TITLE
Small tokens fixes

### DIFF
--- a/src/cc/CCassetstx.cpp
+++ b/src/cc/CCassetstx.cpp
@@ -19,7 +19,6 @@
 
 UniValue AssetOrders(uint256 refassetid, CPubKey pk, uint8_t additionalEvalCode)
 {
-    static uint256 zero;
 	UniValue result(UniValue::VARR);  
 
     struct CCcontract_info *cpAssets, assetsC;
@@ -35,7 +34,7 @@ UniValue AssetOrders(uint256 refassetid, CPubKey pk, uint8_t additionalEvalCode)
 		std::vector<uint8_t> origpubkey;
 		CTransaction ordertx;
 		uint8_t funcid, evalCode;
-		char numstr[32], funcidstr[16], origaddr[64], origtokenaddr[64], assetidstr[65];
+		char numstr[32], funcidstr[16], origaddr[64], origtokenaddr[64];
 
         txid = it->first.txhash;
         LOGSTREAM("ccassets", CCLOG_DEBUG2, stream << "addOrders() checking txid=" << txid.GetHex() << std::endl);
@@ -46,8 +45,8 @@ UniValue AssetOrders(uint256 refassetid, CPubKey pk, uint8_t additionalEvalCode)
             {
                 LOGSTREAM("ccassets", CCLOG_DEBUG2, stream << "addOrders() checking ordertx.vout.size()=" << ordertx.vout.size() << " funcid=" << (char)(funcid ? funcid : ' ') << " assetid=" << assetid.GetHex() << std::endl);
 
-                if (refassetid != zero && assetid == refassetid ||
-                    pk != CPubKey() && pk == pubkey2pk(origpubkey) && (funcid == 'S' || funcid == 's'))
+                if (pk == CPubKey() && (refassetid == zeroid || assetid == refassetid)  // tokenorders
+                    || pk != CPubKey() && pk == pubkey2pk(origpubkey) && (funcid == 'S' || funcid == 's'))  // mytokenorders, returns only asks (is this correct?)
                 {
 
                     LOGSTREAM("ccassets", CCLOG_DEBUG2, stream << "addOrders() it->first.index=" << it->first.index << " ordertx.vout[it->first.index].nValue=" << ordertx.vout[it->first.index].nValue << std::endl);
@@ -61,7 +60,7 @@ UniValue AssetOrders(uint256 refassetid, CPubKey pk, uint8_t additionalEvalCode)
                     funcidstr[0] = funcid;
                     funcidstr[1] = 0;
                     item.push_back(Pair("funcid", funcidstr));
-                    item.push_back(Pair("txid", uint256_str(assetidstr, txid)));
+                    item.push_back(Pair("txid", txid.GetHex()));
                     item.push_back(Pair("vout", (int64_t)it->first.index));
                     if (funcid == 'b' || funcid == 'B')
                     {
@@ -77,18 +76,17 @@ UniValue AssetOrders(uint256 refassetid, CPubKey pk, uint8_t additionalEvalCode)
                         sprintf(numstr, "%llu", (long long)ordertx.vout[0].nValue);
                         item.push_back(Pair("askamount", numstr));
                     }
-                    if (origpubkey.size() == 33)
+                    if (origpubkey.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE)
                     {
                         GetCCaddress(cp, origaddr, pubkey2pk(origpubkey));  
                         item.push_back(Pair("origaddress", origaddr));
                         GetTokensCCaddress(cpTokens, origtokenaddr, pubkey2pk(origpubkey));
                         item.push_back(Pair("origtokenaddress", origtokenaddr));
-
                     }
                     if (assetid != zeroid)
-                        item.push_back(Pair("tokenid", uint256_str(assetidstr, assetid)));
+                        item.push_back(Pair("tokenid", assetid.GetHex()));
                     if (assetid2 != zeroid)
-                        item.push_back(Pair("otherid", uint256_str(assetidstr, assetid2)));
+                        item.push_back(Pair("otherid", assetid2.GetHex()));
                     if (price > 0)
                     {
                         if (funcid == 's' || funcid == 'S' || funcid == 'e' || funcid == 'e')

--- a/src/cc/CCtokens.cpp
+++ b/src/cc/CCtokens.cpp
@@ -824,9 +824,8 @@ std::string CreateToken(int64_t txfee, int64_t tokensupply, std::string name, st
 		txfee = 10000;
 	mypk = pubkey2pk(Mypubkey());
 
-	if (AddNormalinputs(mtx, mypk, tokensupply + 2 * txfee, 64) > 0)
+	if (AddNormalinputs2(mtx, tokensupply + 2 * txfee, 64) > 0)  // add normal inputs only from mypk
 	{
-
         int64_t mypkInputs = TotalPubkeyNormalInputs(mtx, mypk);  
         if (mypkInputs < tokensupply) {     // check that tokens amount are really issued with mypk (because in the wallet there maybe other privkeys)
             CCerror = "some inputs signed not with -pubkey=pk";

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -7663,16 +7663,17 @@ UniValue tokenorders(const UniValue& params, bool fHelp, const CPubKey& mypk)
     uint256 tokenid;
     if ( fHelp || params.size() > 1 )
         throw runtime_error("tokenorders [tokenid]\n"
-                            "returns token orders for the tokenid or all available token orders if tokenid is not set\n" "\n");
+                            "returns token orders for the tokenid or all available token orders if tokenid is not set\n"
+                            "(this rpc supports only fungible tokens)\n" "\n");
     if (ensure_CCrequirements(EVAL_ASSETS) < 0 || ensure_CCrequirements(EVAL_TOKENS) < 0)
         throw runtime_error(CC_REQUIREMENTS_MSG);
 	if (params.size() == 1) {
 		tokenid = Parseuint256((char *)params[0].get_str().c_str());
 		if (tokenid == zeroid) 
 			throw runtime_error("incorrect tokenid\n");
+        return AssetOrders(tokenid, CPubKey(), 0);
 	}
     else {
-        // memset(&tokenid, 0, sizeof(tokenid));
         // throw runtime_error("no tokenid\n");
         return AssetOrders(zeroid, CPubKey(), 0);
     }
@@ -7682,10 +7683,10 @@ UniValue tokenorders(const UniValue& params, bool fHelp, const CPubKey& mypk)
 UniValue mytokenorders(const UniValue& params, bool fHelp, const CPubKey& mypk)
 {
     uint256 tokenid;
-    if (fHelp || params.size() > 2)
+    if (fHelp || params.size() > 1)
         throw runtime_error("mytokenorders [evalcode]\n"
                             "returns all the token orders for mypubkey\n"
-                            "if evalcode is set then returns my token orders for non-fungible tokens with this evalcode\n" "\n");
+                            "if evalcode is set then returns mypubkey token orders for non-fungible tokens with this evalcode\n" "\n");
     if (ensure_CCrequirements(EVAL_ASSETS) < 0 || ensure_CCrequirements(EVAL_TOKENS) < 0)
         throw runtime_error(CC_REQUIREMENTS_MSG);
     uint8_t additionalEvalCode = 0;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -7662,7 +7662,8 @@ UniValue tokenorders(const UniValue& params, bool fHelp, const CPubKey& mypk)
 {
     uint256 tokenid;
     if ( fHelp || params.size() > 1 )
-        throw runtime_error("tokenorders tokenid\n");
+        throw runtime_error("tokenorders [tokenid]\n"
+                            "returns token orders for the tokenid or all available token orders if tokenid is not set\n" "\n");
     if (ensure_CCrequirements(EVAL_ASSETS) < 0 || ensure_CCrequirements(EVAL_TOKENS) < 0)
         throw runtime_error(CC_REQUIREMENTS_MSG);
 	if (params.size() == 1) {
@@ -7672,9 +7673,9 @@ UniValue tokenorders(const UniValue& params, bool fHelp, const CPubKey& mypk)
 	}
     else {
         // memset(&tokenid, 0, sizeof(tokenid));
-        throw runtime_error("no tokenid\n");
+        // throw runtime_error("no tokenid\n");
+        return AssetOrders(zeroid, CPubKey(), 0);
     }
-    return AssetOrders(tokenid, CPubKey(), 0);
 }
 
 
@@ -7682,7 +7683,9 @@ UniValue mytokenorders(const UniValue& params, bool fHelp, const CPubKey& mypk)
 {
     uint256 tokenid;
     if (fHelp || params.size() > 2)
-        throw runtime_error("mytokenorders [evalcode]\n");
+        throw runtime_error("mytokenorders [evalcode]\n"
+                            "returns all the token orders for mypubkey\n"
+                            "if evalcode is set then returns my token orders for non-fungible tokens with this evalcode\n" "\n");
     if (ensure_CCrequirements(EVAL_ASSETS) < 0 || ensure_CCrequirements(EVAL_TOKENS) < 0)
         throw runtime_error(CC_REQUIREMENTS_MSG);
     uint8_t additionalEvalCode = 0;


### PR DESCRIPTION
tokencreate adds normal inputs only from mypk (not from all pk in wallet)
tokenorders allows empty tokenid param and returns all tokenorders as the doc states