### PR TITLE
update libgmp fetch URL

### DIFF
--- a/depends/packages/libgmp.mk
+++ b/depends/packages/libgmp.mk
@@ -18,7 +18,7 @@ $(package)_dependencies=
 $(package)_config_opts=--enable-cxx --disable-shared
 else
 $(package)_version=6.1.1
-$(package)_download_path=https://supernetorg.bintray.com/misc
+$(package)_download_path=https://ftp.gnu.org/gnu/gmp
 $(package)_file_name=gmp-$($(package)_version).tar.bz2
 $(package)_sha256_hash=a8109865f2893f1373b0a8ed5ff7429de8db696fc451b1036bd7bdf95bbeffd6
 $(package)_dependencies=

--- a/depends/packages/libsnark.mk
+++ b/depends/packages/libsnark.mk
@@ -1,6 +1,6 @@
 package=libsnark
 $(package)_version=0.1
-$(package)_download_path=https://supernetorg.bintray.com/misc
+$(package)_download_path=https://github.com/ca333/libsnark/releases/download/v$($(package)_version)-$($(package)_git_commit)/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$(package)-$($(package)_git_commit).tar.gz
 $(package)_sha256_hash=47478adc2ae88c448dc736d59dfe007de6478e41e88d2d4d2ff4135a17ee6f90


### PR DESCRIPTION
hotfix for 404 error when fetching dependency package