### PR TITLE
fix VRSC cli

### DIFF
--- a/src/cc/dapps/subatomic.json
+++ b/src/cc/dapps/subatomic.json
@@ -20,7 +20,7 @@
 "externalcoins":[
     { "BTC":"bitcoin-cli" },
     { "CHIPS":"chips-cli" },
-    { "VRSC":"verus-cli" }
+    { "VRSC":"verus" }
 ]
 }
 


### PR DESCRIPTION
VRSC has `verusd` & `verus`
`verus` is the substitute for `verus-cli`