### PR TITLE
Do not load zksnark params on ac_public chains

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -98,6 +98,7 @@ extern bool komodo_dailysnapshot(int32_t height);
 extern int32_t KOMODO_LOADINGBLOCKS;
 extern bool VERUS_MINTBLOCKS;
 extern char ASSETCHAINS_SYMBOL[];
+extern uint8_t  ASSETCHAINS_PUBLIC;
 extern int32_t KOMODO_SNAPSHOT_INTERVAL;
 
 extern void komodo_init(int32_t height);
@@ -1397,8 +1398,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if ( KOMODO_NSPV_FULLNODE )
     {
-        // Initialize Zcash circuit parameters
-        ZC_LoadParams(chainparams);
+        if ( ASSETCHAINS_PUBLIC ) {
+            LogPrintf("Skipping zksnark circuit param loading on ac_public chain\n");
+        } else {
+            // Initialize Zcash circuit parameters
+            ZC_LoadParams(chainparams);
+        }
     }
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections


### PR DESCRIPTION
Params are loaded during app init before any block data is loaded, so I was not able to look for a recent unix timestamp in the first block.

If necessary, this check could be deferred until block 1 has been loaded. I was able to sync at least 5000 blocks of the WLC21 chain with this code, so it seems to work for existing ac_public chains.

```
2020-03-08 02:28:50 Skipping zksnark circuit param loading on ac_public chain
```